### PR TITLE
Identify "phases" from PCA data using a strategy based on peak identification in 2D projections

### DIFF
--- a/Cameca.CustomAnalysis.Pca/ComponentsTileView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ComponentsTileView.xaml.cs
@@ -39,6 +39,18 @@ public partial class ComponentsTileView : UserControl
         }
     }
 
+    public static readonly DependencyProperty IsPcaPhasesProperty = DependencyProperty.Register(
+        nameof(IsPcaPhases), typeof(bool), typeof(ComponentsTileView), new PropertyMetadata(default(bool)));
+
+
+    public bool? IsPcaPhases
+    {
+        get
+        {  return (bool)GetValue(IsPcaPhasesProperty); }
+        set
+        {  SetValue(IsPcaPhasesProperty, value); }
+    }
+
     public static readonly DependencyProperty RowsProperty = DependencyProperty.Register(
         nameof(Rows), typeof(int), typeof(ComponentsTileView), new PropertyMetadata(default(int)));
 

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
@@ -1,6 +1,6 @@
 ﻿namespace Cameca.CustomAnalysis.Pca;
 
-internal sealed class ComponentResults
+public sealed class ComponentResults
 {
     public float[] Scores { get; }
     public float[] Loads { get; }

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
@@ -1,5 +1,8 @@
 ﻿namespace Cameca.CustomAnalysis.Pca;
 
+
+// public rather than internal because a ComponentsResults object is used to 
+// call the PhaseIdResults constructor
 public sealed class ComponentResults
 {
     public float[] Scores { get; }

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
@@ -1,13 +1,17 @@
 ﻿using Cameca.CustomAnalysis.Interface;
+using System;
+using System.Linq;
 using System.Collections.Generic;
 
 namespace Cameca.CustomAnalysis.Pca;
 
-internal sealed class ComponentsResults
+public sealed class ComponentsResults
 {
     public IGrid3DData Grid3DData { get; }
 
     public int[] VoxelIndices { get; }
+
+    public PhaseIdResults PhaseIDResults { get; set; }
 
     public List<ComponentResults> Components { get; }
 
@@ -16,6 +20,11 @@ internal sealed class ComponentsResults
         Grid3DData = grid3DData;
         VoxelIndices = voxelIndices;
         Components = components;
+
+        List<int> emptyList = new List<int>();
+        emptyList.Add(0);
+        emptyList[0] = 0;
+        PhaseIDResults = new PhaseIdResults(emptyList, 1);
     }
 
 }

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
@@ -21,10 +21,8 @@ public sealed class ComponentsResults
         VoxelIndices = voxelIndices;
         Components = components;
 
-        List<int> emptyList = new List<int>();
-        emptyList.Add(0);
-        emptyList[0] = 0;
-        PhaseIDResults = new PhaseIdResults(emptyList, 1);
+        List<VoxelID> emptyList = new List<VoxelID>();
+        PhaseIDResults = new PhaseIdResults(emptyList);
     }
 
 }

--- a/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Windows.Documents;
+
+namespace Cameca.CustomAnalysis.Pca;
+
+public sealed class TwoDPeakProjection
+{
+    public DensityPlane densityPlane;
+
+    public TwoDPeakProjection(DensityPlane dp)
+    {
+        this.densityPlane = dp;
+    }
+}
+
+public sealed class TwoDPeakProjections
+{
+    public List<TwoDPeakProjection> projections;
+
+    public TwoDPeakProjections(List<TwoDPeakProjection> twoDPeakProjections)
+    {
+        this.projections = twoDPeakProjections;
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -106,7 +106,7 @@ internal static class PcaCalculator
         PcaScoresGridProducer producer = new PcaScoresGridProducer(compResults);
 
         PcaScoresGrid scoresGrid = producer.ScoresGrid();
-        return scoresGrid.GetPhasesStrategyC();
+        return scoresGrid.GetPhasesStrategyE();
     }
 
     public static NoiseEigenvalueResults GetNoiseEigenvalues(float[] evals, int gaps, int significance, bool refine)

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -1,8 +1,45 @@
 ﻿using Cameca.CustomAnalysis.Interface;
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace Cameca.CustomAnalysis.Pca;
+
+public delegate float[] GetScoresDelegate(int voxelIndex);
+
+public class PcaScoresGridProducer: IScoresProvider {
+
+    ComponentsResults compResults;
+    int nComponents;
+
+    public PcaScoresGridProducer(ComponentsResults results)
+    {
+        compResults = results;
+        nComponents = compResults.Components.Count;
+    }
+
+    public float[] GetScores(int voxelIndex)
+    {
+        float[] scores = new float[nComponents];
+        for (int i = 0; i < nComponents; i++)
+        {
+            scores[i] = compResults.Components[i].Scores[voxelIndex];
+        }
+        return scores;
+    }
+
+    public PcaScoresGrid ScoresGrid()
+    {
+
+        int nAllVoxels = compResults.Grid3DData.NumVoxels[0] * compResults.Grid3DData.NumVoxels[1] * compResults.Grid3DData.NumVoxels[2];
+        int nComponents = compResults.Components.Count;
+        List<int> voxelIndices = new List<int>(compResults.VoxelIndices);
+
+        return new PcaScoresGrid(this, voxelIndices, nComponents, compResults.Grid3DData.NumVoxels);
+    }
+}
 
 internal static class PcaCalculator
 {
@@ -57,6 +94,16 @@ internal static class PcaCalculator
         PcaLib.doEigen(nVoxels, nFeatures, dataBuffer, nevals, evals);
 
         return new EigenvalueResults(evals);
+    }
+
+    // manipulate the results of PCA to identify phases per voxel
+    public static PhaseIdResults GetPhases(IIonData ionData, ComponentsResults compResults)
+    {
+        // make a PcaGrid, then call grid.GetPhases
+        PcaScoresGridProducer producer = new PcaScoresGridProducer(compResults);
+
+        PcaScoresGrid scoresGrid = producer.ScoresGrid();
+        return scoresGrid.GetPhasesStrategyC();
     }
 
     public static NoiseEigenvalueResults GetNoiseEigenvalues(float[] evals, int gaps, int significance, bool refine)

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -20,24 +20,27 @@ public class PcaScoresGridProducer: IScoresProvider {
         nComponents = compResults.Components.Count;
     }
 
-    public float[] GetScores(int voxelIndex)
+    public (VoxelID, float[]) GetIDAndScores(int voxelIndex)
     {
         float[] scores = new float[nComponents];
         for (int i = 0; i < nComponents; i++)
         {
             scores[i] = compResults.Components[i].Scores[voxelIndex];
         }
-        return scores;
+        VoxelID voxelId = new VoxelID(compResults.VoxelIndices[voxelIndex]);
+        return (voxelId, scores);
     }
 
     public PcaScoresGrid ScoresGrid()
     {
-
-        int nAllVoxels = compResults.Grid3DData.NumVoxels[0] * compResults.Grid3DData.NumVoxels[1] * compResults.Grid3DData.NumVoxels[2];
         int nComponents = compResults.Components.Count;
-        List<int> voxelIndices = new List<int>(compResults.VoxelIndices);
 
-        return new PcaScoresGrid(this, voxelIndices, nComponents, compResults.Grid3DData.NumVoxels);
+        int x = compResults.Grid3DData.NumVoxels[0];
+        int y = compResults.Grid3DData.NumVoxels[1];
+        int z = compResults.Grid3DData.NumVoxels[2];
+
+        ThreeDGridDimensions gridDimensions = new ThreeDGridDimensions(x, y, z);
+        return new PcaScoresGrid(this, compResults.VoxelIndices.Count(), nComponents, gridDimensions);
     }
 }
 

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -100,11 +100,20 @@
                     </Grid>
                 </utils:ButtonOverlayControl>
             </TabItem>
+
+            <TabItem Header="Grids">
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
+                               ButtonContent="Update"
+                               OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}" />
+
+                </utils:ButtonOverlayControl>
+            </TabItem>
             
             <TabItem Header="Loading">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
                                 ButtonContent="Update"
-                                OverlayVisibility="{Binding UpdateSelectedCopmponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <lvc:CartesianChart Series="{Binding LoadingsSeries}"
                                         DisableAnimations="True"
                                         LegendLocation="None">
@@ -114,7 +123,7 @@
                             </Style>
                         </lvc:CartesianChart.Resources>
                         <lvc:CartesianChart.AxisX>
-                            <lvc:Axis Labels="{Binding LoadingsLables}" FontSize="18">
+                            <lvc:Axis Labels="{Binding LoadingsLabels}" FontSize="18">
                                 <lvc:Axis.Separator>
                                     <lvc:Separator Step="1" />
                                 </lvc:Axis.Separator>
@@ -130,7 +139,7 @@
             <TabItem Header="Scores">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
                             ButtonContent="Update"
-                            OverlayVisibility="{Binding UpdateSelectedCopmponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <controls:Chart2D DataSource="{Binding ScoresHistogramData}"
                                   AxisXLabel="Score"
                                   AxisYLabel="Voxels"/>

--- a/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
+++ b/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using System;
+
+
+// PhaseIDResults represents an assignment of each voxel to an integer phase.
+// in the identifiedPhase Dictionary, the Key is a VoxelID, and the value is its 'phase', 
+// or 0 if no phase is identified
+public class PhaseIdResults
+{
+    Dictionary<int, int> identifiedPhase; 
+
+    public PhaseIdResults(List<int> voxelIndices, int maxIndex)
+    {
+        identifiedPhase = new Dictionary<int, int>();
+        // not-yet-identified voxels are identified as 0
+        for (int i = 0; i < voxelIndices.Count; ++i)
+        {
+            identifiedPhase[voxelIndices[i]] = 0;
+        }
+    }
+
+    public void IdentifyVoxelAs(int voxelId, int phase)
+    {
+        identifiedPhase[voxelId] = phase;
+    }    
+    public void IdentifyVoxelsAs(List<int> voxelIds, int phase)
+    {
+        foreach (int voxelId in voxelIds) {
+            identifiedPhase[voxelId] = phase;
+        }
+    }
+
+    public int? PhaseForVoxel(int voxelId)
+    {
+        if (identifiedPhase.ContainsKey(voxelId))
+        {
+            return identifiedPhase[voxelId];
+        }
+        return null;
+    }
+
+    public List<int> UnidentifiedVoxels()
+    {
+        var unidentifiedIndices = new List<int>();
+        foreach ( KeyValuePair<int, int> voxel in identifiedPhase )
+        {
+            if (voxel.Value == 0) {
+                unidentifiedIndices.Add(voxel.Key);
+            }
+        }
+        return unidentifiedIndices;
+    }
+}
+    
+  

--- a/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
+++ b/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System;
+using Cameca.CustomAnalysis.Pca;
+
 
 
 // PhaseIDResults represents an assignment of each voxel to an integer phase.
@@ -8,30 +10,41 @@ using System;
 // or 0 if no phase is identified
 public class PhaseIdResults
 {
-    Dictionary<int, int> identifiedPhase; 
+    Dictionary<VoxelID, int> identifiedPhase;
+    Dictionary<string, TwoDPeakProjection> twoDPeakProjections;
 
-    public PhaseIdResults(List<int> voxelIndices, int maxIndex)
+    public PhaseIdResults(List<VoxelID> voxelIds)
     {
-        identifiedPhase = new Dictionary<int, int>();
+        identifiedPhase = new Dictionary<VoxelID, int>();
         // not-yet-identified voxels are identified as 0
-        for (int i = 0; i < voxelIndices.Count; ++i)
+        for (int i = 0; i < voxelIds.Count; ++i)
         {
-            identifiedPhase[voxelIndices[i]] = 0;
+            identifiedPhase[voxelIds[i]] = 0;
         }
+        twoDPeakProjections = new Dictionary<string, TwoDPeakProjection>();
     }
 
-    public void IdentifyVoxelAs(int voxelId, int phase)
+    public void SetTwoDPeakProjectionFor(string key, TwoDPeakProjection projection)
+    {
+        twoDPeakProjections[key] = projection;
+    }
+    public Dictionary<string, TwoDPeakProjection> TwoDPeakProjections()
+    {
+        return twoDPeakProjections;
+    }
+
+    public void IdentifyVoxelAs(VoxelID voxelId, int phase)
     {
         identifiedPhase[voxelId] = phase;
-    }    
-    public void IdentifyVoxelsAs(List<int> voxelIds, int phase)
+    }
+    public void IdentifyVoxelsAs(List<VoxelID> voxelIds, int phase)
     {
-        foreach (int voxelId in voxelIds) {
+        foreach (VoxelID voxelId in voxelIds) {
             identifiedPhase[voxelId] = phase;
         }
     }
 
-    public int? PhaseForVoxel(int voxelId)
+    public int? PhaseForVoxel(VoxelID voxelId)
     {
         if (identifiedPhase.ContainsKey(voxelId))
         {
@@ -40,10 +53,20 @@ public class PhaseIdResults
         return null;
     }
 
-    public List<int> UnidentifiedVoxels()
+    public int? PhaseForVoxelIntValue(int voxelIndex)
     {
-        var unidentifiedIndices = new List<int>();
-        foreach ( KeyValuePair<int, int> voxel in identifiedPhase )
+        VoxelID voxelId = new VoxelID(voxelIndex);
+        if (identifiedPhase.ContainsKey(voxelId))
+        {
+            return identifiedPhase[voxelId];
+        }
+        return null;
+    }
+
+    public List<VoxelID> UnidentifiedVoxels()
+    {
+        var unidentifiedIndices = new List<VoxelID>();
+        foreach ( KeyValuePair<VoxelID, int> voxel in identifiedPhase )
         {
             if (voxel.Value == 0) {
                 unidentifiedIndices.Add(voxel.Key);

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -16,6 +16,11 @@ using LiveCharts;
 using LiveCharts.Configurations;
 using LiveCharts.Wpf;
 using System.Collections.ObjectModel;
+using static Cameca.CustomAnalysis.Interface.IonFormula;
+using CommunityToolkit.HighPerformance;
+using System.Windows.Markup;
+using System.Runtime.Intrinsics.Arm;
+using Cameca.Extensions.Controls;
 
 namespace Cameca.CustomAnalysis.Pca;
 
@@ -37,6 +42,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private IColorMap? colorMap = null;
 
     [ObservableProperty]
+    private ICollection<IRenderData> selectedGridRenderData = Array.Empty<IRenderData>();
+
+    [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(UpdateCommand))]
     private EigenvalueResults? eigenvalueResults;
 
@@ -51,19 +59,24 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private ComponentsResults? componentsResults;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateSelectedCopmponentCanExecute))]
+    [NotifyPropertyChangedFor(nameof(UpdateComponentsCanExecute))]
+    [NotifyCanExecuteChangedFor(nameof(UpdateComponentsCommand))]
+    private TwoDPeakProjections? twoDPeakProjections;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
     private SeriesCollection loadingsSeries = new();
 
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateSelectedCopmponentCanExecute))]
+    [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
-    public ICollection<string> loadingsLables = Array.Empty<string>();
+    public ICollection<string> loadingsLabels = Array.Empty<string>();
 
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateSelectedCopmponentCanExecute))]
+    [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
     public ICollection<IRenderData> scoresHistogramData = Array.Empty<IRenderData>();
 
@@ -180,6 +193,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         compResults.PhaseIDResults = phaseIDResults;
 
         ComponentsResults = compResults;
+
+        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults);
+
+        compResults.PhaseIDResults = phaseIDResults;
+
+        ComponentsResults = compResults;
         
         UpdateOptionsBounds();
 
@@ -197,10 +216,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     // Uses the component data (or computes for all componets if necessary) to generate plots for the selected component by index
-    [RelayCommand(CanExecute = nameof(UpdateSelectedCopmponentCanExecute))]
+    [RelayCommand(CanExecute = nameof(UpdateSelectedComponentCanExecute))]
     public async Task UpdateSelectedComponent(CancellationToken cancellationToken)
     {
-        LoadingsLables = Array.Empty<string>();
+        LoadingsLabels = Array.Empty<string>();
         ScoresHistogramData = Array.Empty<IRenderData>();
 
         if (await Resources.GetIonData(cancellationToken: cancellationToken) is not { } ionData)
@@ -246,7 +265,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         {
             series
         };
-        LoadingsLables = ions.Select(x => x.Name).ToList();
+        LoadingsLabels = ions.Select(x => x.Name).ToList();
 
         // Scores Histogram
         int voxels = scores.Length;
@@ -325,21 +344,35 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     // Updates the components 3D plots when the component data (derived from selected number of components) changes
+    float[] GetPhaseIdScoresForVoxelIndices(PhaseIdResults phaseIdResults, int compIndex, int[] voxelIndices)
+    {
+        int numIndices = voxelIndices.Length;
+        float[] scores = new float[numIndices];
+        for (int i = 0; i < numIndices; ++i)
+        {
+            int voxelIndex = voxelIndices[i];
+            scores[i] = phaseIdResults.PhaseForVoxelIntValue(voxelIndex) == compIndex ? 1.0f : 0.0f ;
+        }
+        return scores;
+    }
+
+    // Updates the components 3D plots when the component data (derived from selected number of components) changes
     partial void OnComponentsResultsChanged(ComponentsResults? value)
     {
         ComponentRenderData = Array.Empty<IRenderData>();
+        SelectedGridRenderData = Array.Empty<IRenderData>();
 
-        if (ComponentsResults is not { Grid3DData: { } gridData, 
-                                       Components: { } components,  
-                                       PhaseIDResults: { } phaseIdResults, 
-                                       VoxelIndices: { } voxelIndices }
+        if (ComponentsResults is not { Grid3DData: { } gridData,
+            Components: { } components,
+            PhaseIDResults: { } phaseIdResults,
+            VoxelIndices: { } voxelIndices }
          || Resources.GetValidIonData() is not { } ionData)
         {
             return;
         }
 
-        int numComponents = Properties.Components;
-        int selectedIndex = Properties.ComponentIndex;
+        int numComponents = 6; // was hardwired to numComponents  Properties.Components;
+        // int selectedIndex = Properties.ComponentIndex;
 
         var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 
@@ -347,7 +380,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         IValuePointsRenderData? rootValuePoints = null;
         for (int compIndex = 0; compIndex < numComponents; compIndex++)
         {
-            var scores = components[compIndex].Scores;
+
             var phaseIdScores = GetPhaseIdScoresForVoxelIndices(phaseIdResults, compIndex, voxelIndices);
 
             // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
@@ -379,6 +412,19 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
 
         ComponentRenderData = newComponentsData;
+
+        var peakProjections = phaseIdResults.TwoDPeakProjections();
+        int gridCount = peakProjections.Count;
+        var newGridProjectionsData = new List<IRenderData>();
+        foreach (KeyValuePair<string, TwoDPeakProjection> kvp in peakProjections)
+        {
+            var histogram = Resources.ChartObjects.CreateHistogram2D();
+            histogram.Name = kvp.Key;
+            histogram.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
+            FillRenderDataWithGridData(histogram, kvp.Value);
+            newGridProjectionsData.Add(histogram);
+        }
+        SelectedGridRenderData = newGridProjectionsData;
     }
 
     private static (float Low, float High) GetRange(IEnumerable<float[]> scores)
@@ -452,6 +498,32 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         };
     }
 
+    public void FillRenderDataWithGridData(IHistogram2DRenderData renderData, TwoDPeakProjection projection)
+    {
+        // renderData.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
+        DensityPlane dp = projection.densityPlane;
+        (TwoDGridCoord minCoord, TwoDGridCoord maxCoord) = dp.MinMaxGridCoords();
+        int spanX = 1 + maxCoord.x - minCoord.x;
+        int spanY = 1 + maxCoord.y - minCoord.y;
+        int span = Math.Max(spanX, spanY);
+        int numCoords = span * span;
+        float[] dat = new float[numCoords * 4];
+        for (int q = 0; q < spanY; q += 1)
+        {
+            int qOffset = q * span;
+            int gridq = q + minCoord.y;
+            for (int p = 0; p < spanX; p += 1)
+            {
+                int arrayIndex = qOffset + p;
+                int gridp = p + minCoord.x;
+                dat[arrayIndex] = dp.valueAtGridCoords(gridp, gridq);
+            }
+        }
+        ReadOnlyMemory2D<float> rom = new ReadOnlyMemory2D<float>(dat, span, span);
+        Vector2 binsize = new Vector2(0.5f, 0.5f); // Vector2(dp.binsize, dp.binsize);
+        Vector2 origin = new Vector2(minCoord.x * dp.binsize, minCoord.y * dp.binsize);
+        renderData.Update(rom, binsize, origin);
+    }
     // Updates readonly Min/Max properties so the bounds are displayed in the Properties panel 
     private void UpdateOptionsBounds()
     {
@@ -502,10 +574,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
             for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
             {
-                var bin = binner.ToVoxel(positions.Span[chunkIndex]);
+                int bin = binner.ToVoxel(positions.Span[chunkIndex]);
 
                 // Properties.ComponentIndex is the selectedComponent
-                if (phaseIds.PhaseForVoxel(bin) == componentOfInterest) 
+                if (phaseIds.PhaseForVoxelIntValue(bin) == componentOfInterest) 
                 // if (scoredVoxels.TryGetValue(bin, out float score) && score >= threshold)
                 {
                     buffer.Span[bufferIndex++] = index;
@@ -570,7 +642,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         DataStateIsValid = true;
     }
     */
-    
+
     // On Properties panel changes, some data must be invalidated to be recomputed with new values. Invalidations depend on the properties changed
     protected override void OnPropertiesChanged(PropertyChangedEventArgs e)
     {
@@ -603,7 +675,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private void InvalidateSelectedComponent()
     {
         LoadingsSeries = new SeriesCollection();
-        LoadingsLables = Array.Empty<string>();
+        LoadingsLabels = Array.Empty<string>();
         ScoresHistogramData = Array.Empty<IRenderData>();
     }
 

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -173,8 +173,14 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             return;
         }
 
-        ComponentsResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
+        var compResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
 
+        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults);
+
+        compResults.PhaseIDResults = phaseIDResults;
+
+        ComponentsResults = compResults;
+        
         UpdateOptionsBounds();
 
         // Ensure that the selected component falls in the valid range of number of components
@@ -280,6 +286,19 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         EigenvalueRenderData.Add(series);
     }
 
+    // Updates the components 3D plots when the component data (derived from selected number of components) changes
+    float[] GetPhaseIdScoresForVoxelIndices(PhaseIdResults phaseIdResults, int compIndex, int[] voxelIndices)
+    {
+        int numIndices = voxelIndices.Length;
+        float[] scores = new float[numIndices];
+        for (int i = 0; i < numIndices; ++i)
+        {
+            int voxelIndex = voxelIndices[i];
+            scores[i] = phaseIdResults.PhaseForVoxel(voxelIndex) == compIndex ? 1.0f : 0.0f ;
+        }
+        return scores;
+    }
+    
     partial void OnNoiseEigenvalueResultsChanged(NoiseEigenvalueResults? value)
     {
         if (NoiseEigenvalueResults is { Rank: int rank, NoiseEvals: float[] noiseEvals })
@@ -310,7 +329,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         ComponentRenderData = Array.Empty<IRenderData>();
 
-        if (ComponentsResults is not { Grid3DData: { } gridData, Components: { } components, VoxelIndices: { } voxelIndices }
+        if (ComponentsResults is not { Grid3DData: { } gridData, 
+                                       Components: { } components,  
+                                       PhaseIDResults: { } phaseIdResults, 
+                                       VoxelIndices: { } voxelIndices }
          || Resources.GetValidIonData() is not { } ionData)
         {
             return;
@@ -326,7 +348,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         for (int compIndex = 0; compIndex < numComponents; compIndex++)
         {
             var scores = components[compIndex].Scores;
-            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, scores, jitterStdDev: jitterStdDev);
+            var phaseIdScores = GetPhaseIdScoresForVoxelIndices(phaseIdResults, compIndex, voxelIndices);
+
+            // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
+            // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
+            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, phaseIdScores);
 
             var valuePoints = Resources.ChartObjects.CreateValuePoints();
             valuePoints.Name = $"Component {compIndex}";
@@ -435,6 +461,64 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     // Applies filter to the custom analysis: returns the ions in voxels for which the score of the selected component exceeds the specified threshold value
+    // Olof Note -- this is where to change logic for viewing results -- redirect the algorithm here to look at the new 'identified phase' structure
+  
+    protected override async IAsyncEnumerable<ReadOnlyMemory<ulong>> GetIndicesDelegateAsync(IIonData ionData, IProgress<double>? progress, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        DataStateIsError = false;
+        if (ComponentsResults is null)
+        {
+            await UpdateComponents(cancellationToken);
+        }
+
+        // Extract necessary data out of ComponentsResults using some pattern matching for null checks and variable assignment
+        if (ComponentsResults is not { Grid3DData: { } gridData, VoxelIndices: { } nonEmptyVoxels }
+            || ComponentsResults.Components[Properties.ComponentIndex] is not { Scores: { } scores })
+        {
+            DataStateIsError = true;
+            yield break;
+        }
+        var phaseIds = ComponentsResults.PhaseIDResults;
+        int componentOfInterest = Properties.ComponentIndex;
+        var minVector = gridData.GetMinVector();
+        var voxelSize = gridData.GetVoxelSizeDimensions();
+        int xBinStride = gridData.NumVoxels[0];
+        int yBinStride = gridData.NumVoxels[1];
+        var binner = new PositionToVoxels(minVector, voxelSize, xBinStride, yBinStride);
+
+        // Create a map of voxel index to the associated score
+        var scoredVoxels = nonEmptyVoxels
+            .Zip(scores)
+            .ToDictionary(x => x.First, x => x.Second);
+
+        // Build buffers of filtered indices to return
+        // Iterating through each point (to determine inclusion) is a bit of a complex chunked iterator code to support >Int32.MaxValue number of ions in a data set
+        ulong index = 0ul;
+        float threshold = Properties.Isovalue;
+        foreach (var chunk in ionData.CreateSectionDataEnumerable(IonDataSectionName.Position))
+        {
+            int bufferIndex = 0;
+            using var buffer = MemoryOwner<ulong>.Allocate(chunk.Length);
+            var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
+            for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
+            {
+                var bin = binner.ToVoxel(positions.Span[chunkIndex]);
+
+                // Properties.ComponentIndex is the selectedComponent
+                if (phaseIds.PhaseForVoxel(bin) == componentOfInterest) 
+                // if (scoredVoxels.TryGetValue(bin, out float score) && score >= threshold)
+                {
+                    buffer.Span[bufferIndex++] = index;
+                }
+                index += 1ul;
+            }
+            yield return buffer.Slice(0, bufferIndex).Memory;
+        }
+
+        DataStateIsValid = true;
+    }
+
+    /*
     protected override async IAsyncEnumerable<ReadOnlyMemory<ulong>> GetIndicesDelegateAsync(IIonData ionData, IProgress<double>? progress, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         DataStateIsError = false;
@@ -485,7 +569,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         DataStateIsValid = true;
     }
-
+    */
+    
     // On Properties panel changes, some data must be invalidated to be recomputed with new values. Invalidations depend on the properties changed
     protected override void OnPropertiesChanged(PropertyChangedEventArgs e)
     {

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -84,8 +84,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
 
-    public bool UpdateSelectedCopmponentCanExecute =>
-        !LoadingsSeries.Any() || !LoadingsLables.Any() || !ScoresHistogramData.Any();
+    public bool UpdateSelectedComponentCanExecute =>
+        !LoadingsSeries.Any() || !LoadingsLabels.Any() || !ScoresHistogramData.Any();
 
     public Func<double, string> AxisYLabelFormatter { get; } = (double value) => value.ToString("F3");
 
@@ -187,12 +187,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
 
         var compResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
-
-        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults);
-
-        compResults.PhaseIDResults = phaseIDResults;
-
-        ComponentsResults = compResults;
 
         var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults);
 
@@ -313,11 +307,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         for (int i = 0; i < numIndices; ++i)
         {
             int voxelIndex = voxelIndices[i];
-            scores[i] = phaseIdResults.PhaseForVoxel(voxelIndex) == compIndex ? 1.0f : 0.0f ;
+            scores[i] = phaseIdResults.PhaseForVoxelIntValue(voxelIndex) == compIndex ? 1.0f : 0.0f ;
         }
         return scores;
     }
-    
+
     partial void OnNoiseEigenvalueResultsChanged(NoiseEigenvalueResults? value)
     {
         if (NoiseEigenvalueResults is { Rank: int rank, NoiseEvals: float[] noiseEvals })
@@ -341,19 +335,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
             EigenvalueRenderData.Add(noiseSeries);
         }
-    }
-
-    // Updates the components 3D plots when the component data (derived from selected number of components) changes
-    float[] GetPhaseIdScoresForVoxelIndices(PhaseIdResults phaseIdResults, int compIndex, int[] voxelIndices)
-    {
-        int numIndices = voxelIndices.Length;
-        float[] scores = new float[numIndices];
-        for (int i = 0; i < numIndices; ++i)
-        {
-            int voxelIndex = voxelIndices[i];
-            scores[i] = phaseIdResults.PhaseForVoxelIntValue(voxelIndex) == compIndex ? 1.0f : 0.0f ;
-        }
-        return scores;
     }
 
     // Updates the components 3D plots when the component data (derived from selected number of components) changes

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -39,6 +39,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private ICollection<IRenderData> componentRenderData = Array.Empty<IRenderData>();
 
     [ObservableProperty]
+    private ICollection<IRenderData> pcaPhasesRenderData = Array.Empty<IRenderData>();
+
+    [ObservableProperty]
     private IColorMap? colorMap = null;
 
     [ObservableProperty]
@@ -341,6 +344,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     partial void OnComponentsResultsChanged(ComponentsResults? value)
     {
         ComponentRenderData = Array.Empty<IRenderData>();
+        PcaPhasesRenderData = Array.Empty<IRenderData>();
         SelectedGridRenderData = Array.Empty<IRenderData>();
 
         if (ComponentsResults is not { Grid3DData: { } gridData,
@@ -352,8 +356,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             return;
         }
 
-        int numComponents = 6; // was hardwired to numComponents  Properties.Components;
-        // int selectedIndex = Properties.ComponentIndex;
+        int numComponents = Properties.Components;
+        int selectedIndex = Properties.ComponentIndex;
 
         var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 
@@ -361,12 +365,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         IValuePointsRenderData? rootValuePoints = null;
         for (int compIndex = 0; compIndex < numComponents; compIndex++)
         {
-
-            var phaseIdScores = GetPhaseIdScoresForVoxelIndices(phaseIdResults, compIndex, voxelIndices);
-
-            // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
-            // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
-            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, phaseIdScores);
+            var scores = components[compIndex].Scores;
+            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, scores, jitterStdDev: jitterStdDev);
 
             var valuePoints = Resources.ChartObjects.CreateValuePoints();
             valuePoints.Name = $"Component {compIndex}";
@@ -393,6 +393,58 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
 
         ComponentRenderData = newComponentsData;
+
+        //Almost the same as ComponentRenderData, but PcaRenderData
+        int numPhases = 7; // need to figure out how to not hard code
+        // int selectedIndex = Properties.ComponentIndex;
+
+        var newPhasesData = new IRenderData[numPhases];
+        IValuePointsRenderData? rootValuePoints2 = null;
+        for (int compIndex = 0; compIndex < numPhases; compIndex++)
+        {
+
+            var phaseIdScores = GetPhaseIdScoresForVoxelIndices(phaseIdResults, compIndex, voxelIndices);
+
+            // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
+            // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
+            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, phaseIdScores);
+
+            var valuePoints = Resources.ChartObjects.CreateValuePoints();
+            if (compIndex == 0)
+            {
+                valuePoints.Name = $"Unassigned Voxels";
+            }
+            else if (compIndex == (numPhases - 1)) 
+            {
+                valuePoints.Name = $"Interface Voxels";
+            }
+            else
+            {
+                valuePoints.Name = $"Pca Phase {compIndex}";
+            }
+                
+            valuePoints.PositionsWithValues = positionsWithValues;
+            if (rootValuePoints2 is null)
+            {
+                rootValuePoints2 = valuePoints;
+                rootValuePoints2.ColorMap = DeserializeColorMap(Properties.ColorMap);
+            }
+            else
+            {
+                valuePoints.ColorMap = rootValuePoints2.ColorMap;
+            }
+
+            newPhasesData[compIndex] = valuePoints;
+        }
+
+        if (rootValuePoints?.ColorMap is not null)
+        {
+            ColorMap = rootValuePoints.ColorMap;
+            ColorMap.BottomValue = 0.0f;
+            ColorMap.TopValue = 1.0f;
+        }
+
+        PcaPhasesRenderData = newPhasesData;
 
         var peakProjections = phaseIdResults.TwoDPeakProjections();
         int gridCount = peakProjections.Count;
@@ -502,7 +554,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
         ReadOnlyMemory2D<float> rom = new ReadOnlyMemory2D<float>(dat, span, span);
         Vector2 binsize = new Vector2(0.5f, 0.5f); // Vector2(dp.binsize, dp.binsize);
-        Vector2 origin = new Vector2(minCoord.x * dp.binsize, minCoord.y * dp.binsize);
+        Vector2 origin = new Vector2(minCoord.y * dp.binsize, minCoord.x * dp.binsize);
         renderData.Update(rom, binsize, origin);
     }
     // Updates readonly Min/Max properties so the bounds are displayed in the Properties panel 

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl x:Class="Cameca.CustomAnalysis.Pca.ProjectionGridsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Cameca.CustomAnalysis.Pca"
+             xmlns:interface="clr-namespace:Cameca.CustomAnalysis.Interface;assembly=Cameca.CustomAnalysis.Interface"
+             xmlns:controls="clr-namespace:Cameca.Extensions.Controls;assembly=Cameca.Extensions.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <local:SingleRenderDataValueConverter x:Key="SingleRenderDataValueConverter" />
+    </UserControl.Resources>
+    <Grid>
+        
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        
+        <StackPanel Grid.Row="0" Orientation="Horizontal">
+            <Button x:Name="AdvanceGridButton" Content="Advance To Next Grid" Height="32" Width="140"
+                Click="AdvanceGridButton_Click">
+            </Button>
+        </StackPanel>
+
+        <controls:Histogram2D x:Name="ProjectionGrid2dHistogram" Grid.Row="1" DataSource="{Binding SelectedGridRenderData, RelativeSource={RelativeSource AncestorType=local:ProjectionGridsView}}"
+             AxisXLabel="PCA dimension 1"
+             AxisYLabel="PCA dimension 0"/>
+
+    </Grid>
+</UserControl>

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -1,0 +1,150 @@
+﻿using Cameca.CustomAnalysis.Interface;
+using Cameca.CustomAnalysis.Utilities;
+using Cameca.Extensions.Controls;
+using CommunityToolkit.HighPerformance;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Numerics;
+using System.Runtime.Intrinsics.Arm;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace Cameca.CustomAnalysis.Pca;
+
+/// <summary>
+/// Interaction logic for ProjectionGridsView.xaml
+/// </summary>
+public partial class ProjectionGridsView : UserControl
+{
+
+    int whichGrid = 0;
+    public ProjectionGridsView()
+    {
+        InitializeComponent();
+        var histogram = ProjectionGrid2dHistogram;
+    }
+
+    public static readonly DependencyProperty GridsSourceProperty = DependencyProperty.Register(
+        nameof(GridsSource),
+        typeof(ICollection<IRenderData>),
+        typeof(ProjectionGridsView),
+        new FrameworkPropertyMetadata(Array.Empty<IRenderData>(), GridsSourcePropertyChanged));
+
+    private static void GridsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ProjectionGridsView projectionGridsView) { return; }
+        ICollection<IRenderData> renderData = projectionGridsView.GridsSource;
+        int rdc = renderData.Count;
+        Debug.WriteLine("GridsSourcePropertyChanged called -- render data count is " + rdc);
+    }
+
+    private void GridsSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RefreshGridData();
+    }
+
+    internal string AxisYLabelForGridID(string gridID)
+    {
+        string[] components = gridID.Split("-");
+        if (components.Count() != 2)
+        {
+            return "Unknown Pca Axis";
+        }
+        string component = components[0];
+        return "PCA Component " + component.Substring(1);
+    }
+    internal string AxisXLabelForGridID(string gridID)
+    {
+        string[] components = gridID.Split("-");
+        if (components.Count() != 2)
+        {
+            return "Unknown Pca Axis";
+        }
+        string component = components[1];
+        return "PCA Component " + component;
+    }
+
+    private void RefreshGridData()
+    { 
+        ICollection<IRenderData> renderDataCollection = this.GridsSource;
+        int rdc = renderDataCollection.Count;
+        if (rdc > 0)
+        {
+            List<IRenderData> renderList = renderDataCollection.ToList();
+            if (whichGrid >= rdc)
+            {
+                whichGrid = 0;
+            }
+
+            var renderData = renderList[whichGrid];
+            List<IRenderData> singleList = new List<IRenderData> { renderData };
+            Histogram2D histogram = ProjectionGrid2dHistogram;
+            histogram.AxisXLabel = AxisXLabelForGridID(renderData.Name);
+            histogram.AxisYLabel = AxisYLabelForGridID(renderData.Name);
+            histogram.DataSource = singleList;
+        }
+    }
+
+    public void FillRenderDataWithGridData(IHistogram2DRenderData renderData, TwoDPeakProjection projection)
+    {
+       // renderData.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
+        DensityPlane dp = projection.densityPlane;
+        (TwoDGridCoord minCoord, TwoDGridCoord maxCoord) = dp.MinMaxGridCoords();
+        int spanX = 1 + maxCoord.x - minCoord.x;
+        int spanY = 1 + maxCoord.y - minCoord.y;
+        int span = Math.Max(spanX, spanY);
+        int numCoords = span * span;
+        float[] dat = new float[numCoords * 4];
+        for (int q = 0; q < spanY; q += 1)
+        {
+            int qOffset = q * span;
+            int gridq = q + minCoord.y;
+            for (int p = 0; p < spanX; p += 1)
+            {
+                int arrayIndex = qOffset + p;
+                int gridp = p + minCoord.x;
+                dat[arrayIndex] = dp.valueAtGridCoords(gridp, gridq);
+            }
+        }
+        ReadOnlyMemory2D<float> rom = new ReadOnlyMemory2D<float>(dat, span, span);
+        Vector2 binsize = new Vector2(0.5f, 0.5f); // Vector2(dp.binsize, dp.binsize);
+        Vector2 origin = new Vector2(minCoord.x * dp.binsize, minCoord.y * dp.binsize);
+        renderData.Update(rom, binsize, origin);
+    }
+
+    public ICollection<IRenderData> GridsSource
+    {
+        get { return (ICollection<IRenderData>)GetValue(GridsSourceProperty); }
+        set { SetValue(GridsSourceProperty, value); }
+    }
+
+    private void AdvanceGridButton_Click(object sender, RoutedEventArgs e)
+    {
+        whichGrid += 1;
+        RefreshGridData();
+    }
+
+    private static IEnumerable<T> GetChildren<T>(DependencyObject root) where T: DependencyObject
+    {
+        int childrenCount = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < childrenCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T)
+            {
+                yield return (T)child;
+            }
+            foreach (var recursiveChild in GetChildren<T>(child))
+            {
+                yield return recursiveChild;
+            }
+        }
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/Utils/HashSet.cs
+++ b/Cameca.CustomAnalysis.Pca/Utils/HashSet.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PcaExtensionMethods
+{
+    public static class HashSetExt
+    {
+        // AddSorted assumes that the list is already sorted. An item is added 
+        // so that the sort order is maintained.
+        // there is no attempt made to put "ties" either before or after items 
+        // which already exist in the list.  
+        // that is, if the list contains {H1, K2, L3}, (sorting by the number values) 
+        // and item M2 is added the result could be either {H1, K2, M2, L3}  or {H1, M2, K2, L3}
+        public static bool ContainsAny<T>(this HashSet<T> self, IEnumerable<T> collection)  
+        {
+            foreach(T t in collection)
+            {
+                if (self.Contains(t)) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/Utils/SortedList.cs
+++ b/Cameca.CustomAnalysis.Pca/Utils/SortedList.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PcaExtensionMethods
+{
+    public static class ListExt
+    {
+        // AddSorted assumes that the list is already sorted. An item is added 
+        // so that the sort order is maintained.
+        // there is no attempt made to put "ties" either before or after items 
+        // which already exist in the list.  
+        // that is, if the list contains {H1, K2, L3}, (sorting by the number values) 
+        // and item M2 is added the result could be either {H1, K2, M2, L3}  or {H1, M2, K2, L3}
+        public static void AddSorted<T>(this List<T> self, T item) where T : IComparable<T>
+        {
+            if (self.Count == 0)
+            {
+                self.Add(item);
+                return;
+            }
+            if (self[self.Count - 1].CompareTo(item) <= 0)
+            {
+                self.Add(item);
+                return;
+            }
+            if (self[0].CompareTo(item) >= 0)
+            {
+                self.Insert(0, item);
+                return;
+            }
+            int index = self.BinarySearch(item);
+            if (index < 0)
+                index = ~index;
+            self.Insert(index, item);
+        }
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/CandidateRanker.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/CandidateRanker.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using System.IO;
+ 
+// CandidateRanker is used to identify the 'best' candidates from all the PixelSuggestion 
+// objects it is asked to consider. Items added to the list of candidates are the 'best'
+// until a better candidate is nominated.
+//
+// It would only be a small amount of work to generalize this to any IComparable instead
+// instead of hard coding the reference to PixelSuggestion and PixelSuggestion.score
+//
+// It is used in the Peak separation algorithm -- each peak nominates the next pixel 
+// for inclusion in a peak, so the number of items to be considered is the number of peaks
+// There's not much 
+
+public class CandidateRanker
+{
+    float bestScore;
+    List<PixelSuggestion> candidates;  
+    public CandidateRanker()
+    {
+        bestScore = -1.0f;
+        candidates = new List<PixelSuggestion> ();
+    }
+
+    public void Clear()
+    {
+        bestScore = -1.0f;
+        candidates.Clear();
+    }
+    
+    public void Consider(PixelSuggestion suggestion)
+    {
+        float suggestionScore = suggestion.score;
+        if (suggestionScore >= bestScore)  
+        {
+            if (suggestionScore > bestScore)
+            {
+                bestScore = suggestionScore;
+                candidates.Clear();
+            }
+            candidates.Add(suggestion);
+        } 
+    }
+
+    public List<PixelSuggestion>  bestCandidates()
+    {
+        return candidates;
+    }
+}
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -1,0 +1,388 @@
+
+using System;
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using static System.Formats.Asn1.AsnWriter;
+
+public struct PixelID : IComparable<PixelID>
+{
+    public int pixelId;
+
+    public PixelID(int pixelId)
+    {
+        this.pixelId = pixelId;
+    }
+
+    public PixelID(int x, int y)
+    {
+        pixelId = y * 1024 + x;
+    }
+    public (int, int) xyCoords()
+    {
+        int y = (512 + pixelId) >> 10;
+        int x = pixelId - (y * 1024);
+        return (x, y);
+    }
+
+    public int CompareTo(PixelID other)
+    {
+        return other.pixelId > pixelId ? -1 : other.pixelId < pixelId ? 1 : 0;
+    }
+    public string DebugStr()
+    {
+        int x;
+        int y;
+        (x, y) = this.xyCoords();
+        return pixelId.ToString() + ":{" + x + "," + y + "}";
+    }
+}
+
+
+public struct PeakID
+{
+    PixelID peakMax;
+    public PeakID(PixelID pixelId)
+    {
+        peakMax = pixelId;
+    }
+
+    public string DebugStr()
+    {
+        return peakMax.DebugStr();
+    }
+}
+
+// DensityPlane represents a 2D density plot, and the bins exist on a 2D grid
+// Bins are regularly spaced from the minimum to the maximum
+// a binsize maps a floating point coordinate to a grid coordinate.
+// if the binsize is 1, then the grid coordinate at p-1, q=1 represents the floating point coordinate 1.0, 1.0
+// if the binsize is 0.5, then the grid coordinate at p-1, q=1 represents the floating point coordinate 0.5, 0.5
+// Bins have an integer id derived from their p and q coordinates :  1024q + p 
+// So, for a binsize of 1.0, the xy coordinate 3.0,4.0 would correspond to 
+// the bin at p = 3, q = 4 and the ID would be 4099
+// if the binsize is 0.5, a point at x=3, y=4 would be the gridpoint p=6, q=8, and the ID would be 8198
+//
+// The data is collected in a Dictionary<int, float>
+// if a bin is unpopulated, there is no Dictionary entry for the corresponding ID
+// smoothing is applied at population time: when a point is added,  it is automatically split 
+// between bins to preserve a constant smoothing for all added points
+// There is always a bin at zero
+// bins at negative values have negative indices
+// "out of bounds" limits at -510 and 510
+//  points outside of the bounds are counted but not binned
+// 
+// Points are added to the Plane using a splat transfer function, in a way that the 
+// delocalization for every point added to the profile is almost constant.  That is,
+// if a point is added at a corner of the grid, equidistant from four different grid points, 
+// it contributes .25 to each of the four bins The 1 dimensional transfer function is used in both 
+// dimensions, so that if a point is added exactly at a grid point, it only contributes 9/16 to that point
+// and 7/16 to the surrounding points following this matrix of contributions:
+//
+//   1/64   3/32   1/64
+//   3/32   9/16   3/32 
+//   1/64   3/32   1/64
+public class DensityPlane
+{
+    float halfBinsize;
+    float binsize;
+    float oneOverBinsize;
+    int oobPoints;
+    float maxval;
+    Dictionary<PixelID, float> data;
+    
+    public DensityPlane(float binSep)
+    {
+        binsize = binSep;
+        halfBinsize = binSep * 0.5f; 
+        oobPoints = 0;
+        oneOverBinsize = 1.0f / binSep;
+        data = new Dictionary<PixelID, float>();
+        maxval = 1022.0f * binSep;
+    }
+    
+    public List<PixelID> GridPointIds()
+    {
+        return data.Keys.ToList();
+    }
+    
+    public List<PixelID> PixelIdsNeighboring(PixelID pixelId)
+    {
+        int x;
+        int y;
+        (x, y) = pixelId.xyCoords();
+        List<PixelID> neighbors = new List<PixelID>();
+        PixelID neighborBin = new PixelID(x - 1, y);
+        if (data.ContainsKey(neighborBin))
+        {
+            neighbors.Add(neighborBin);
+        }
+		neighborBin = new PixelID(x + 1, y);
+		if (data.ContainsKey(neighborBin))
+		{
+			neighbors.Add(neighborBin);
+		}
+		neighborBin = new PixelID(x, y - 1);
+		if (data.ContainsKey(neighborBin))
+		{
+			neighbors.Add(neighborBin);
+		}
+		neighborBin = new PixelID(x, y + 1);
+		if (data.ContainsKey(neighborBin))
+		{
+			neighbors.Add(neighborBin);
+		}
+		return neighbors;
+	}
+	
+    public float MaximumValue(List<PixelID> candidates)
+    {
+        float maxScore = float.MinValue;
+
+        foreach (PixelID candidate in candidates)
+        {
+            float nthScore = valueAtPixel(candidate);
+            if (nthScore > maxScore)
+            {
+                maxScore = nthScore;
+            }
+        }
+        return maxScore;
+    }
+    
+    public PixelID? FindMaximum(List<PixelID> candidates)
+    {
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+        PixelID bestCandidate = candidates[0];
+        float currMax = valueAtPixel(bestCandidate);
+        foreach (PixelID candidate in candidates)
+        {
+            float nthPopulation = valueAtPixel(candidate);
+            if (nthPopulation > currMax)
+            {
+                currMax = nthPopulation;
+                bestCandidate = candidate;
+            }
+        }
+        return bestCandidate;
+    }
+    
+    public (TwoDGridCoord, TwoDGridCoord) MinMaxGridCoords()
+    {
+        int miny = 0;
+        int minx = 0;
+        int maxy = 0;
+        int maxx = 0;
+        bool first = true;
+      
+        var pixelIds = data.Keys.ToList();
+        pixelIds.Sort();
+        foreach (PixelID pixelId in pixelIds)
+        {
+            int x;
+            int y;
+            (x, y) = pixelId.xyCoords();
+            if (!first)
+            {
+                miny = Math.Min(y, miny);
+                maxy = Math.Max(y, maxy);
+                minx = Math.Min(x, minx);
+                maxx = Math.Max(x, maxx);
+            }
+            else
+            {
+                miny = y;
+                maxy = y;
+                minx = x;
+                maxx = x;
+                first = false;
+            }
+            float binx = x * binsize;
+            float biny = y * binsize;
+            // Debug.WriteLine("x = " + binx + ",y = " + biny + ", population = " + data[key]);
+        }
+        return (new TwoDGridCoord(minx, miny), new TwoDGridCoord(maxx, maxy));
+    }
+    
+    public void WriteToStream(StreamWriter stream)
+    {
+        TwoDGridCoord min;
+        TwoDGridCoord max;
+        (min, max) = MinMaxGridCoords();
+
+        int xSize = 1 + max.x - min.x;
+		int ySize = 1 + max.y - min.y;
+		stream.WriteLine("x size= " + xSize);
+		stream.WriteLine("y size= " + ySize);
+
+		stream.Write("{ " );
+		// now csv data for the grid from min to max
+		for (int y = min.y; y <= max.y; ++y)
+		{
+			string l = "{";
+			for (int x = min.x; x <= max.x; ++x)
+			{
+				PixelID xthKey = new PixelID(x, y);
+				float xthValue = 0;
+				if (data.ContainsKey(xthKey))
+				{
+					xthValue = data[xthKey];
+				}
+				l = l + xthValue;
+				if (x != max.x) {
+					l = l + ",";
+				}  
+			}
+			l = l + "}";
+			stream.Write(l);
+			if (y != max.y)
+			{
+				stream.Write(",");
+			}
+		}
+		stream.Write("}");
+    }
+    
+    public void ConsoleDump(string prefix)
+    {
+        int miny = 0; 
+        int minx = 0;
+        int maxy = 0;
+        int maxx = 0;
+        bool first = true;
+        Debug.WriteLine("DensityProfile Dump " + prefix);
+        var pixelIds = data.Keys.ToList();
+        pixelIds.Sort();
+        foreach (PixelID pixelId in pixelIds)
+        {
+            int x;
+            int y;
+            (x, y) = pixelId.xyCoords();
+            if (!first)
+            {
+                miny = Math.Min(y, miny);
+                maxy = Math.Max(y, maxy); 
+                minx = Math.Min(x, minx);
+                maxx = Math.Max(x, maxx);
+            }
+            else
+            {
+                miny = y;
+                maxy = y;
+                minx = x;
+                maxx = x;
+                first = false;
+            }
+            float binx = x * binsize;
+            float biny = y * binsize;
+            Debug.WriteLine("x = " + binx + ",y = " + biny + ", population = " + data[pixelId]);
+        }
+    }
+    
+    public void writeToFile(string outputFilename)
+    {   
+        string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        using (StreamWriter outputFile = new StreamWriter(outputFilename))
+        {
+            this.WriteToStream(outputFile);
+        }
+    }
+    
+    public float valueAtPixel(PixelID pixelId)
+    {
+        float binValue;
+        if (data.TryGetValue(pixelId, out binValue))
+        {
+            return binValue;
+        }
+        return 0.0f;
+    }
+    
+    PixelID BinFor(int x, int y)
+    {
+        return new PixelID(y * 1024 + x);
+    }
+
+    public (int, int) PixelIndicesFor(float x, float y)
+    {
+        int xBinIndex = (int)MathF.Floor((x + halfBinsize) * oneOverBinsize);
+        int yBinIndex = (int)MathF.Floor((y + halfBinsize) * oneOverBinsize);
+        return (xBinIndex, yBinIndex);
+    }
+
+    public PixelID PixelIDFor(float x, float y)
+    {
+        int binx;
+        int biny;
+        (binx, biny) = PixelIndicesFor(x, y);
+        return new PixelID(binx, biny);
+    }
+
+    public void AddPointAt(float x, float y)
+    {
+        if ((Math.Abs(x) > maxval) || (Math.Abs(y) > maxval)) {
+            oobPoints += 1;
+            return;
+        }
+
+        float Neg1Func(float x)
+        {
+            return (.5f * MathF.Pow(x - 0.5f, 2));
+        }
+
+        float ZeroFunc(float x)
+        {
+            return (.75f - MathF.Pow(x, 2));
+        }
+
+        float Pos1Func(float x)
+        {
+            return (.5f * MathF.Pow(x + 0.5f, 2));
+        }
+
+        int xBinIndex;
+        int yBinIndex;
+        (xBinIndex, yBinIndex) = PixelIndicesFor(x, y);
+
+        float xRem = (x - (xBinIndex * binsize)) * oneOverBinsize;
+        float xm1 = (float)Neg1Func(xRem);
+        float xp1 = (float)Pos1Func(xRem);    // these are the spline transfer functions
+        float x0 = (float)ZeroFunc(xRem); 
+       
+        float yRem = (y - (yBinIndex * binsize)) * oneOverBinsize;
+        float ym1 = (float)Neg1Func(yRem);
+        float yp1 = (float)Pos1Func(yRem);    // these are the spline transfer functions
+        float y0 = (float)ZeroFunc(yRem);
+
+        PixelID bin = new PixelID(xBinIndex - 1, yBinIndex - 1);
+        data[bin] = valueAtPixel(bin) + xm1 * ym1;
+        bin = new PixelID(xBinIndex, yBinIndex - 1);
+        data[bin] = valueAtPixel(bin) + x0 * ym1;
+        bin = new PixelID(xBinIndex + 1, yBinIndex - 1);
+        data[bin] = valueAtPixel(bin) + xp1 * ym1;
+
+        bin = new PixelID(xBinIndex - 1, yBinIndex);
+        data[bin] = valueAtPixel(bin) + xm1 * y0;
+        bin = new PixelID(xBinIndex, yBinIndex);
+        data[bin] = valueAtPixel(bin) + x0 * y0;
+        bin = new PixelID(xBinIndex + 1, yBinIndex);
+        data[bin] = valueAtPixel(bin) + xp1 * y0;
+
+        bin = new PixelID(xBinIndex - 1, yBinIndex + 1);
+        data[bin] = valueAtPixel(bin) + xm1 * yp1;
+        bin = new PixelID(xBinIndex, yBinIndex + 1);
+        data[bin] = valueAtPixel(bin) + x0 * yp1;
+        bin = new PixelID(xBinIndex + 1, yBinIndex + 1);
+        data[bin] = valueAtPixel(bin) + xp1 * yp1;
+
+    }
+
+}
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -5,7 +5,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using static System.Formats.Asn1.AsnWriter;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.Arm;
+using System.Windows.Controls;
+using System.Text.RegularExpressions;
 
 public struct PixelID : IComparable<PixelID>
 {
@@ -87,7 +90,7 @@ public struct PeakID
 public class DensityPlane
 {
     float halfBinsize;
-    float binsize;
+    public float binsize;
     float oneOverBinsize;
     int oobPoints;
     float maxval;
@@ -107,33 +110,32 @@ public class DensityPlane
     {
         return data.Keys.ToList();
     }
-    
+
+    internal void AddIfPossible(int x, int y, List<PixelID> list)
+    {
+        PixelID possibleBin = new PixelID(x, y);
+        if (data.ContainsKey(possibleBin))
+        {
+            list.Add(possibleBin);
+        }
+    }
+
+    // check for the 8 neighboring pixels and add them if they have a non-zero value
     public List<PixelID> PixelIdsNeighboring(PixelID pixelId)
     {
-        int x;
-        int y;
-        (x, y) = pixelId.xyCoords();
+        //int x;
+        //int y;
+        (int x, int y) = pixelId.xyCoords();
         List<PixelID> neighbors = new List<PixelID>();
-        PixelID neighborBin = new PixelID(x - 1, y);
-        if (data.ContainsKey(neighborBin))
-        {
-            neighbors.Add(neighborBin);
-        }
-		neighborBin = new PixelID(x + 1, y);
-		if (data.ContainsKey(neighborBin))
-		{
-			neighbors.Add(neighborBin);
-		}
-		neighborBin = new PixelID(x, y - 1);
-		if (data.ContainsKey(neighborBin))
-		{
-			neighbors.Add(neighborBin);
-		}
-		neighborBin = new PixelID(x, y + 1);
-		if (data.ContainsKey(neighborBin))
-		{
-			neighbors.Add(neighborBin);
-		}
+        AddIfPossible(x - 1, y - 1, neighbors);
+        AddIfPossible(x - 1, y, neighbors);
+        AddIfPossible(x - 1, y + 1, neighbors);
+        AddIfPossible(x, y-1, neighbors);
+        AddIfPossible(x, y+1, neighbors);
+        AddIfPossible(x + 1, y-1, neighbors);
+        AddIfPossible(x + 1, y, neighbors);
+        AddIfPossible(x + 1, y + 1, neighbors);
+
 		return neighbors;
 	}
 	
@@ -292,7 +294,13 @@ public class DensityPlane
             this.WriteToStream(outputFile);
         }
     }
-    
+
+    public float valueAtGridCoords(int x, int y)
+    {
+        PixelID pixelId = this.BinFor(x, y);
+        return this.valueAtPixel(pixelId);
+    }
+
     public float valueAtPixel(PixelID pixelId)
     {
         float binValue;
@@ -302,8 +310,8 @@ public class DensityPlane
         }
         return 0.0f;
     }
-    
-    PixelID BinFor(int x, int y)
+
+    public PixelID BinFor(int x, int y)
     {
         return new PixelID(y * 1024 + x);
     }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using System.IO;
+
+
+// DensityProfile represents a histogram-ish population along one axis
+// Bins are regularly spaced from the minimum to the maximum
+// Bins have an integer id according to their distance from 0
+// So, if the axis coordinate is 2, and the bins are 0.5 apart, the bin is ID=4
+// The data is collected in a Dictionary<int, float>
+// if a bin is unpopulated, there is no Dictionary entry for the corresponding ID
+// smoothing is applied at population time: when a point is added,  it is automatically split 
+// between bins to preserve a constant smoothing for all added points
+// There is always a bin at zero
+// bins at negative values have negative indices
+// "out of bounds" limits at -1023 and 1023
+//  points outside of the bounds are counted but not binned
+// Points are added to the profile using a splat transfer function, in a way that the 
+// delocalization for every point added to the profile is constant.  That is,
+// if a point is added at the center of a bin, it contributes .75 to that bin and .125 to each neighbor bin
+// If a point is added exactly at the border between two bins, it contributes 0.5 to each one
+
+public class DensityProfile
+{
+    float maxval;
+    float halfBinsize;
+    float binsize;
+    float oneOverBinsize;
+    int oobPoints;
+    Dictionary<int, float> data;
+    public DensityProfile(float binsize)
+    {
+        this.maxval = binsize * 1023.0f;
+        this.halfBinsize = binsize * 0.5f;
+        this.binsize = binsize;
+        this.oneOverBinsize = 1.0f / binsize;
+        this.data = new Dictionary<int, float>();
+        this.oobPoints = 0;
+    }
+
+    public void ConsoleDump(string prefix)
+    {
+        Debug.WriteLine("DensityProfile Dump " + prefix);
+        var keys = data.Keys.ToList();
+        keys.Sort();
+        foreach (var key in keys)
+        {
+            float binx = key * binsize;
+            Debug.WriteLine("x = " + binx + ", population = " + data[key]);
+        }
+    }
+    internal float populationAtBin(int bin)
+    {
+        float binValue = 0.0f;
+        if (data.ContainsKey(bin))
+        {
+            binValue = data[bin];
+        }
+        return binValue;
+    }
+
+    public void AddPointAt(float x)
+    {
+        if (Math.Abs(x) > maxval)
+        {
+            oobPoints += 1;
+            return;
+        }
+
+        float Neg1Func(float x)
+        {
+            return (.5f * MathF.Pow(x - 0.5f, 2));
+        }
+
+        float ZeroFunc(float x)
+        {
+            return (.75f - MathF.Pow(x, 2));
+        }
+
+        float Pos1Func(float x)
+        {
+            return (.5f * MathF.Pow(x + 0.5f, 2));
+        }
+
+        int binIndex = (int)MathF.Floor((x + halfBinsize) * oneOverBinsize);
+        float xRem = (x - (binIndex * binsize)) * oneOverBinsize;
+
+        float xm1 = (float)Neg1Func(xRem);
+        float xp1 = (float)Pos1Func(xRem);    // these are the spline transfer functions
+        float x0 = (float)ZeroFunc(xRem);
+        data[binIndex] = populationAtBin(binIndex) + x0;
+        data[binIndex - 1] = populationAtBin(binIndex - 1) + xm1;
+        data[binIndex + 1] = populationAtBin(binIndex + 1) + xp1;
+    }
+
+}
+
+
+
+
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/GridCoord.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/GridCoord.cs
@@ -17,21 +17,73 @@ public struct TwoDGridCoord
     {
         Console.WriteLine(prefix + this.x, ", ", + this.y);
     }
-}; 
+};
+
+// ThreeDGridDimensions represents the size of a voxel grid -- 
+// To specify a specific voxel in the grid, use a ThreeDGridCoord instead
+public struct ThreeDGridDimensions
+{
+    public int x;
+    public int y;
+    public int z;
+    public int xy;  // we often use this product, so multiple once and use that
+    public int xyz;  // this is the number of voxels
+
+    public ThreeDGridDimensions(int x, int y, int z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        int xy = x * y;
+        this.xy = xy;
+        this.xyz = xy * z;
+    }
+
+    public void ToConsole(string prefix)
+    {
+        Console.WriteLine(prefix + this.x, ", ", +this.y, ", ", +this.z);
+    }
+    public bool VoxelExists(int p, int q, int r)
+    {
+         return p >= 0 && q >= 0 && r >= 0 && p < x && q < y && r < z;
+    }
+
+    public VoxelID VoxelIdFor(int p, int q, int r)
+    {
+        int voxelIdIntValue = VoxelIdIntValueFor(p, q, r);
+        return new VoxelID(voxelIdIntValue);
+    }
+
+    public int VoxelIdIntValueFor(int p, int q, int r)
+    {
+        return  p + (q * x) + (r * xy);
+    }
+
+    public int NumVoxels()
+    {
+        return this.xyz; 
+    }
+}
 
 // GridCoord is a triplet of integers identifying a point on a Three Dimensional grid
-public struct GridCoord
+public struct ThreeDGridCoord
 {
     public int x;
     public int y;
     public int z;
 
-    public GridCoord(int x, int y, int z)
+    public ThreeDGridCoord(int x, int y, int z)
     {
         this.x = x;
         this.y = y;
         this.z = z;
     }
+
+    public VoxelID VoxelIdFor(ThreeDGridDimensions gridDims)
+    {
+        return gridDims.VoxelIdFor(x, y, z);
+    }
+
     public void ToConsole(string prefix)
     {
         Console.WriteLine(prefix + this.x, ", ", +this.y, ", ", +this.z);

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/GridCoord.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/GridCoord.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System;
+
+
+// TwoDGridCoord is a pair of integers identifying a point on a Two Dimensional grid
+public struct TwoDGridCoord
+{
+    public int x;
+    public int y;
+
+    public TwoDGridCoord(int x, int y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+    public void ToConsole(string prefix)
+    {
+        Console.WriteLine(prefix + this.x, ", ", + this.y);
+    }
+}; 
+
+// GridCoord is a triplet of integers identifying a point on a Three Dimensional grid
+public struct GridCoord
+{
+    public int x;
+    public int y;
+    public int z;
+
+    public GridCoord(int x, int y, int z)
+    {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+    public void ToConsole(string prefix)
+    {
+        Console.WriteLine(prefix + this.x, ", ", +this.y, ", ", +this.z);
+    }
+};
+
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -1,10 +1,20 @@
+
+using PcaExtensionMethods;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System;
 using System.IO;
- 
- 
+using System.Windows.Controls;
+using System.Collections;
+using System.Windows.Input;
+using System.Text;
+using System.Windows.Media.Animation;
+using System.Reflection.PortableExecutable;
+using Cameca.CustomAnalysis.Pca;
+using System.Runtime.Intrinsics.Arm;
+
+
 // PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
 // PcaScoresGrid is initialized with the size of the grid in x y and z, so that it can then map 
 // a particular [x,y,z] grid coordinate to an index (and back) 
@@ -15,89 +25,165 @@ using System.IO;
 
 public interface IScoresProvider
 {
-    public float[] GetScores(int voxelIndex);
+    public (VoxelID, float[]) GetIDAndScores(int voxelIndex);
 }
 public class PcaScoresGrid
 {
-    Dictionary<int, PcaVoxel> pcaVoxels; // the key is the 'id' for the voxel, from which you can
-                                         // calculate the x,y,z position of the voxel on the grid if
-                                         // the grid dimensions are known
+    Dictionary<VoxelID, PcaVoxel> pcaVoxels; // the key is the 'id' for the voxel, from which you can
+                                             // calculate the x,y,z position of the voxel on the grid if
+                                             // the grid dimensions are known
 
     int scoreDims;
-    int xDim;
-    int yDim;
-    int zDim;
-    int nVoxels;
+    ThreeDGridDimensions gridDims;
 
-    int VoxelIndexFor(GridCoord gridCoord)
+    public VoxelID VoxelIDFor(ThreeDGridCoord gridCoord)
     {
-        return gridCoord.x + (gridCoord.y * xDim) + (gridCoord.z * xDim * yDim);
+        return gridCoord.VoxelIdFor(gridDims);
     }
 
-    GridCoord GridCoordFor(int voxelIndex)
+    public ThreeDGridCoord GridCoordFor(VoxelID voxelId)
     {
-        int zOffset = xDim * yDim;
-        int yOffset = xDim;
-        int zCoord = voxelIndex / zOffset;
-        int rem = voxelIndex % zOffset;
-        int yCoord = rem / yOffset;
-        rem = rem % yOffset;
-        int xCoord = rem;
-        return new GridCoord(xCoord, yCoord, zCoord);
+        return voxelId.GridCoordFor(gridDims);
     }
 
+    // really just the ASCII value of the first character
+    internal int ASCIIValueForChar(char s)
+    {
+        return (int)s;
+    }
+
+    internal char CharValueForASCII(int a)
+    {
+        return (char)a;
+    }
     // returns a list of 27 indices, unless the voxel is near the edge
-    List<int> NeighborIndicesFor(GridCoord gridCoord)
+    // note: also includes self
+    List<VoxelID> NeighborIDsFor(ThreeDGridCoord gridCoord)
     {
-        List<int> neighborIndices = new List<int>();
-        //List<int> xIndices = new List<int>();
-        //List<int> yIndices = new List<int>();
-        //List<int> zIndices = new List<int>();
+        List<VoxelID> neighborIndices = new List<VoxelID>();
+
         int minx = Math.Max(0, gridCoord.x - 1);
-        int maxx = Math.Min(xDim - 1, gridCoord.x + 1);
+        int maxx = Math.Min(gridDims.x - 1, gridCoord.x + 1);
         int miny = Math.Max(0, gridCoord.y - 1);
-        int maxy = Math.Min(yDim - 1, gridCoord.y + 1);
+        int maxy = Math.Min(gridDims.y - 1, gridCoord.y + 1);
         int minz = Math.Max(0, gridCoord.z - 1);
-        int maxz = Math.Min(zDim - 1, gridCoord.z + 1);
+        int maxz = Math.Min(gridDims.z - 1, gridCoord.z + 1);
         for (int z = minz; z <= maxz; ++z)
         {
             for (int y = miny; y <= maxy; ++y)
             {
                 for (int x = minx; x <= maxx; ++x)
                 {
-                    neighborIndices.Add(x + (y * xDim) + (z * xDim * yDim));
+                    VoxelID voxelId = new VoxelID(x + (y * gridDims.x) + (z * gridDims.xy));
+                    neighborIndices.Add(voxelId);
                 }
             }
         }
         return neighborIndices;
     }
-    public PcaScoresGrid(IScoresProvider scoresProvider, List<int> voxelIndices, int scoreDimensions, int[] gridDimensions)
+
+    public PcaScoresGrid(IScoresProvider scoresProvider, int nIndices, int scoreDimensions, ThreeDGridDimensions gridDimensions)
     {
         scoreDims = scoreDimensions;
 
-        pcaVoxels = pcaVoxelsInit(scoresProvider, voxelIndices, gridDimensions);
+        pcaVoxels = pcaVoxelsInit(scoresProvider, nIndices);
 
-        xDim = gridDimensions[0];
-        yDim = gridDimensions[1];
-        zDim = gridDimensions[2];
-
-        nVoxels = xDim * yDim * zDim;
+        gridDims = gridDimensions;
     }
 
-    static Dictionary<int, PcaVoxel> pcaVoxelsInit(IScoresProvider scoresProvider, List<int> voxelIndices, int[] gridDimensions)
+    static Dictionary<VoxelID, PcaVoxel> pcaVoxelsInit(IScoresProvider scoresProvider, int nIndices)
     {
-        var voxels = new Dictionary<int, PcaVoxel>();
-        int nIndices = voxelIndices.Count;
+        var voxels = new Dictionary<VoxelID, PcaVoxel>();
 
         for (int i = 0; i < nIndices; ++i)
         {
-            float[] nthVector = scoresProvider.GetScores(i);
+            float[] nthVector;
+            VoxelID voxelId;
 
-            var pcaVoxel = new PcaVoxel(voxelIndices[i], nthVector);
-            voxels[voxelIndices[i]] = pcaVoxel;
+            (voxelId, nthVector) = scoresProvider.GetIDAndScores(i);
+
+            var pcaVoxel = new PcaVoxel(voxelId, nthVector);
+            voxels[voxelId] = pcaVoxel;
         }
 
         return voxels;
+    }
+
+    // When assigning each voxel to a phase based on which peak it might be in,
+    // We want to avoid mapping each pixel to a peak more than once
+    // SO, first  put all the voxels into a different list corresponding to each pixel
+    // then we can do the lookup once and assign all the voxels from that pixel to 
+    // the same phase
+    Dictionary<PixelID, List<VoxelID>> aggregateVoxelsIntoListsPerPixel(List<VoxelID> voxelIds, DensityPlane grid, Dictionary<VoxelID, PcaVoxel> pcaVoxels, int firstDim, int secondDim)
+    {
+        // For each voxel, assign the voxel to the List corresponding with its pixel
+        Dictionary<PixelID, List<VoxelID>> voxelLists = new Dictionary<PixelID, List<VoxelID>>();
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            PcaVoxel voxel = pcaVoxels[voxelId];
+            PixelID nthPixelId = grid.PixelIDFor(voxel.scoreVector[firstDim], voxel.scoreVector[secondDim]);
+            List<VoxelID>? voxelIDListForGridCoord;
+            if (voxelLists.TryGetValue(nthPixelId, out voxelIDListForGridCoord))
+            {
+                voxelIDListForGridCoord.Add(voxelId);
+            }
+            else
+            {
+                voxelIDListForGridCoord = new List<VoxelID>();
+                voxelIDListForGridCoord.Add(voxelId);
+                voxelLists[nthPixelId] = voxelIDListForGridCoord;
+            }
+        }
+        return voxelLists;
+    }
+
+    // VoxelBuckets essentially inverts the dictionary passed in
+    // returns a dictionary where the key is the pcaCode string,
+    // and the value is a HashSet of VoxelIDs with that pcaCode
+    internal Dictionary<string, HashSet<VoxelID>> VoxelBuckets(Dictionary<VoxelID, string> pcaCodes)
+    {
+        Dictionary<string, HashSet<VoxelID>> buckets = new Dictionary<string, HashSet<VoxelID>>();
+        foreach (KeyValuePair<VoxelID, string> kvp in pcaCodes)
+        {
+            if (buckets.ContainsKey(kvp.Value))
+            {
+                buckets[kvp.Value].Add(kvp.Key);
+            }
+            else
+            {
+                HashSet<VoxelID> newSet = new HashSet<VoxelID>();
+                newSet.Add(kvp.Key);
+                buckets[kvp.Value] = newSet;
+            }
+        }
+        return buckets;
+    }
+    internal Dictionary<string, int> PcaCodeCounts(Dictionary<string, HashSet<VoxelID>> voxelBuckets)
+    {
+        Dictionary<string, int> pcaCodeCounts = new Dictionary<string, int>();
+        foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in voxelBuckets)
+        {
+            pcaCodeCounts[kvp.Key] = kvp.Value.Count;
+        }
+        return pcaCodeCounts;
+    }
+    internal void DumpPcaCodeCounts(Dictionary<string, int> pcaCodeCounts)
+    {
+        string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        string outputFilename = System.IO.Path.Combine(docPath, "PcaCodeStats.txt");
+
+        using (StreamWriter outputFile = new StreamWriter(outputFilename))
+        {
+            List<string> sortedCodes = pcaCodeCounts.Keys.ToList();
+            sortedCodes.Sort();
+            outputFile.WriteLine("PcaCodeStats file");
+            foreach (string pcaCode in sortedCodes)
+            {
+                int count = pcaCodeCounts[pcaCode];
+                outputFile.WriteLine("Code: \t" + pcaCode + "\t Count:\t" + count);
+            }
+            outputFile.Close();
+        }
     }
 
     // GetPhasesStrategyC is produces PhaseIdResults based on the first two 
@@ -111,16 +197,15 @@ public class PcaScoresGrid
     // C) assign voxels with PCA scores in each peak to the corresponding phase
     public PhaseIdResults GetPhasesStrategyC()
     {
-        List<int> voxelIndices = pcaVoxels.Keys.ToList();
+        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
 
-        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIndices, nVoxels);
+        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
         float binSeparation = 0.5f;
         int gridDims = Math.Min(2, this.scoreDims); // 2 is the simplest choice 
         Dictionary<int, DensityPlane> twoDGrids = new Dictionary<int, DensityPlane>();
         Dictionary<int, List<List<PixelID>>> partitions = new Dictionary<int, List<List<PixelID>>>();
-        
-        
+
         // now, make twoD grids using all pairs of dimensions
         // yes, GetPhasesStrategyC only uses 2 dimensions, so these loops are useless, 
         // but they will be used in successive strategies when there are more dimensions used
@@ -129,13 +214,14 @@ public class PcaScoresGrid
             for (int j = i + 1; j < gridDims; ++j)
             {
                 int gridId = 10 * i + j;
-                
+
                 // this makes the 2D grid  --  step A) above
-                var twoDGrid = CalculateTwoDDensity(voxelIndices, i, j, binSeparation);
+                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
                 twoDGrids[gridId] = twoDGrid;
-                
+
                 // this identifies the peaks --  step B) above
-                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j, voxelIndices);
+                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
+
                 partitions[gridId] = partitionedIndices;
             }
         }
@@ -195,30 +281,13 @@ public class PcaScoresGrid
             }
             */
             // end of debug dump
-            
-            // For each voxel, assign the voxel to the List corresponding with its pixel
-            Dictionary<PixelID, List<int>> voxelLists = new Dictionary<PixelID, List<int>>();
-            foreach (int voxelId in voxelIndices)
-            {
-                PcaVoxel voxel = pcaVoxels[voxelId];
-                PixelID nthPixelId = grid.PixelIDFor(voxel.scoreVector[0], voxel.scoreVector[1]);
-                List<int>? voxelIDListForGridCoord;
-                if (voxelLists.TryGetValue(nthPixelId, out voxelIDListForGridCoord))
-                {
-                    voxelIDListForGridCoord.Add(voxelId);
-                }
-                else
-                {
-                    voxelIDListForGridCoord = new List<int>();
-                    voxelIDListForGridCoord.Add(voxelId);
-                    voxelLists[nthPixelId] = voxelIDListForGridCoord;
-                }
-            }
+
+            Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, grid, pcaVoxels, 0, 1);
 
             // now, each voxelIndex is a member of one of the lists in voxelLists
             // go through each list in voxelLists and see if its pixel is designated in a particular partiion
             // that is, for each pixel, see which peak it belongs to, if any
-             
+
             int listN = 1;
             foreach (List<PixelID> pixelIdList in firstGridPartitions)
             {
@@ -226,8 +295,9 @@ public class PcaScoresGrid
                 foreach (PixelID pixelID in pixelIdList)
                 {
                     // Lookup for all the voxels bucketed under this pixelId
-                    List<int> voxelIds = voxelLists[pixelID];
-                    foreach (int voxelId in voxelIds)
+                    List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                    foreach (VoxelID voxelId in voxelIdsForThisPixel)
+
                     {
                         phaseIdResults.IdentifyVoxelAs(voxelId, listN);
                     }
@@ -244,8 +314,8 @@ public class PcaScoresGrid
             foreach (PixelID pixelID in unassignedPixels)
             {
                 // Lookup for all the voxels bucketed under this pixelId
-                List<int> voxelIds = voxelLists[pixelID];
-                foreach (int voxelId in voxelIds)
+                List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                foreach (VoxelID voxelId in voxelIdsForThisPixel)
                 {
                     phaseIdResults.IdentifyVoxelAs(voxelId, 0);
                 }
@@ -254,6 +324,553 @@ public class PcaScoresGrid
 
         return phaseIdResults;
     }
+    internal void DumpPartitions(List<List<PixelID>> partitions, string gridId)
+    {
+        string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        string outputFilename = System.IO.Path.Combine(docPath, "PcaPeakPartitions" + gridId + ".txt");
+        // int peakIndex = 1;
+        using (StreamWriter outputFile = new StreamWriter(outputFilename))
+        {
+            outputFile.Write("peakCoords = {");
+            bool firstPeak = true;
+            foreach (List<PixelID> partition in partitions)
+            {
+                if (!firstPeak)
+                {
+                    outputFile.Write(",");
+                }
+                else
+                {
+                    firstPeak = false;
+                }
+                outputFile.Write("{");
+                bool firstCoord = true;
+                foreach (PixelID pixelId in partition)
+                {
+                    (int x, int y) = pixelId.xyCoords();
+                    if (!firstCoord) {
+                        outputFile.Write(",");
+                    }
+                    else
+                    {
+                        firstCoord = false;
+                    }
+                    outputFile.Write("{" + x + "," + y + "}");
+                }
+                outputFile.WriteLine("}¨\n");
+                //  peakIndex += 1;
+            }
+
+            outputFile.Write("}");
+            outputFile.Close();
+        }
+    }
+    // GetPhasesStrategyD is produces PhaseIdResults based on the first three 
+    // PCA dimensions only  
+    //
+    // The strategy goes like this:
+    //
+    // A) make three 2D grids representing the density of voxels with PCA scores in 
+    //    each combination of the first three PCA dimensions 
+    //    in other words dim1xdim2,  dim1xdim3,  dim2xdim3
+    // B) identify peaks in each 2D grid -- each peak corresponds to a section of a PCA code
+    //      A1 is a code snippet representing the first peak of the first grid
+    //      A2 is a code snippet representing the second peak of the first grid  
+    //      B1 is a code snippet representing the first peak of the second grid    
+    //      B0 is a code snippet representing no association with any peak of the second grid
+    //      etc.
+    // C) identify the top 4 buckets and assign those to phases
+    //      assign all the rest to phase 0
+    //  note -- steps A and B are identical  to GetPhasesStrategyD
+    //          step C is just a shortcut to identifying phases to make sure the code was working
+    public PhaseIdResults GetPhasesStrategyD()
+    {
+        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
+
+        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
+
+        float binSeparation = 0.5f;
+        int gridDims = Math.Min(3, this.scoreDims); // 3 for strategy D
+        Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
+        Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
+
+        // make a dictionary for the pcaCodes and fill with enpty Strings
+        Dictionary<VoxelID, string> pcaCodes = new Dictionary<VoxelID, string>();
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            pcaCodes[voxelId] = "";
+        }
+
+        int AAsciiValue = ASCIIValueForChar('A');
+        int gridIndex = 0;
+        // now, make twoD grids using all pairs of dimensions
+        for (int i = 0; i < (gridDims - 1); ++i)
+        {
+            for (int j = i + 1; j < gridDims; ++j)
+            {
+                string gridLetter = CharValueForASCII(AAsciiValue + gridIndex).ToString();
+                string gridId = gridLetter + i.ToString() + j.ToString();
+
+                // this makes the 2D grid  --  step A) above
+                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
+                twoDGrids[gridId] = twoDGrid;
+
+                // this identifies the peaks --  step B) above
+                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
+                partitions[gridId] = partitionedIndices;
+                DumpPartitions(partitionedIndices, gridId);
+
+                // now label each voxel with a PCA code based on its peak association
+                // for each grid, group the voxels into lists per pixel, then, knowing
+                // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
+                // the PCA code dictionary
+                int peakIndex = 1;
+                Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, i, j);
+                foreach (List<PixelID> pixelIdList in partitionedIndices)
+                {
+                    string pcaCode = gridLetter + "." + peakIndex.ToString();
+                    // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
+                    foreach (PixelID pixelID in pixelIdList)
+                    {
+                        // Lookup for all the voxels bucketed under this pixelId
+                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                        {
+                            pcaCodes[voxelId] = pcaCodes[voxelId] + pcaCode;
+                        }
+                        // remove that entry from voxelLists
+                        voxelLists.Remove(pixelID);
+                    }
+                    peakIndex += 1;
+                }
+
+                // now, all the remaining entries in voxelLists are unassigned :  
+                // assign these to component 0
+                string unassignedPcaCode = gridLetter + ".0";
+                List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
+                foreach (PixelID pixelID in unassignedPixels)
+                {
+                    // Lookup for all the voxels bucketed under this pixelId
+                    List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                    foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                    {
+                        pcaCodes[voxelId] = pcaCodes[voxelId] + unassignedPcaCode;
+                    }
+                }
+                gridIndex += 1;
+            }
+        }
+
+        // now examine the groups of voxels to identify contiguous regions
+        // first, lets dump some info about populations of all the different 
+        // pca Codes:
+        Dictionary<string, HashSet<VoxelID>> voxelBuckets = VoxelBuckets(pcaCodes);
+
+        // first, lets dump some info about populations of all the different 
+        // pca Codes:
+        Dictionary<string, int> pcaCodeCounts = PcaCodeCounts(voxelBuckets);
+        DumpPcaCodeCounts(pcaCodeCounts);
+
+
+        // preliminary strategy D:
+        // just find the highest populated 4 buckets in pcaCodeCounts, assign those as 
+        // the first 4 components
+        // leave the voxel coagulation until later
+
+        // phaseIDResults has a method  IdentifyVoxelAs(int voxelIds, int phase)
+        List<KeyValuePair<string, int>> kvpList = pcaCodeCounts.ToList<KeyValuePair<string, int>>();
+        List<KeyValuePair<string, int>> sortedKvpList = kvpList.OrderByDescending(kvp => kvp.Value).ToList();
+        Dictionary<string, int> phaseAssignments = new Dictionary<string, int>();
+        int phase = 1;
+        foreach (KeyValuePair<string, int> kvp in sortedKvpList)
+        {
+            phaseAssignments[kvp.Key] = phase;
+            phase += 1;
+        }
+
+        // and, call IdentifyVoxelAs for each voxel
+        // now, all the remaining entries in voxelLists are unassigned :  
+        // assign these to component 0
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            string pcaCode = pcaCodes[voxelId];
+            int voxelphase = phaseAssignments[pcaCode];
+            if (voxelphase > 4)
+            {
+                voxelphase = 0;
+            }
+
+            phaseIdResults.IdentifyVoxelAs(voxelId, voxelphase);
+        }
+        return phaseIdResults;
+    }
+
+    internal List<VoxelID> FindMatchingSets(VoxelID neighborID, Dictionary<VoxelID, HashSet<VoxelID>> voxelSets)
+    {
+        List<VoxelID> matchingSets = new List<VoxelID>();
+        foreach (KeyValuePair<VoxelID, HashSet<VoxelID>> kvp in voxelSets)
+        {
+            if (kvp.Value.Contains(neighborID))
+            {
+                matchingSets.Add(kvp.Key);
+            }
+        }
+        return matchingSets;
+    }
+
+    // filterForMatchableCode identifies which of the pcaCodes in nonZeroPcaCodes are
+    // 'one-away' matches for pcaCode
+    // The reason we use a . to separate the letter from the number in PCA codes is to 
+    // make it easy to identify a zero -- i.e. the algorithm here also
+    // works if there are 10 peaks, because "A.10" doesn't contain ".0"
+    internal HashSet<string> filterForMatchableCode(List<string> nonZeroPcaCodes, string pcaCode)
+    {
+        // if pcaCode contains zero 0s or more than one 0, return empty List
+        HashSet<string> matches = new HashSet<string>();
+        string[] components = pcaCode.Split(".0");
+        if (components.Count() == 2)
+        {
+            // now, matching is easy -- see if both components of the split are part of a candidate code
+            // and if so, its a match.  Edge case for when the second component is zero length -- no need to check there
+
+            foreach (string candidate in nonZeroPcaCodes)
+            {
+                if (candidate.Contains(components[0]) &&
+                     ((components[1].Length == 0) || candidate.Contains(components[1])))
+                {
+                    matches.Add(candidate);
+                }
+            }
+        }
+        return matches;
+    }
+
+    string interfaceIdForCodes(List<string> pcaCodes)
+    {
+        List<string> codesList = new List<string>(pcaCodes);
+        codesList.Sort();
+        string interfaceId = codesList[0];
+        int numCodes = codesList.Count();
+        for (int i = 1; i < numCodes; ++i)
+        {
+            interfaceId += "," + codesList[i];
+        }
+        return interfaceId;
+    }
+
+    void addVoxelsToHashSetDictionary(Dictionary<string, HashSet<VoxelID>> additions, Dictionary<string, HashSet<VoxelID>> sets)
+    {
+        foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in additions)
+        {
+            HashSet<VoxelID> hashSet;
+            if (sets.ContainsKey(kvp.Key))
+            {
+                hashSet = sets[kvp.Key];
+            }
+            else
+            {
+                hashSet = new HashSet<VoxelID>();
+            }
+            foreach (VoxelID voxelId in kvp.Value)
+            {
+                hashSet.Add(voxelId);
+            }
+            sets[kvp.Key] = hashSet;
+        }
+    }
+
+    
+    void subtractVoxelsFromHashSetDictionary(Dictionary<string, HashSet<VoxelID>> subtractions, Dictionary<string, HashSet<VoxelID>> sets)
+    {
+        foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in subtractions)
+        {
+            HashSet<VoxelID> hashSet;
+            if (sets.ContainsKey(kvp.Key))
+            {
+                hashSet = sets[kvp.Key];
+            }
+            else
+            {
+                hashSet = new HashSet<VoxelID>();
+            }
+            foreach (VoxelID voxelId in kvp.Value)
+            {
+                hashSet.Remove(voxelId);
+            }
+            sets[kvp.Key] = hashSet;
+        }
+    }
+    
+    // GetPhasesStrategyE is produces PhaseIdResults based on the first three 
+    // PCA dimensions only  
+    //
+    // The strategy goes like this:
+    //
+    // A) make three 2D grids representing the density of voxels with PCA scores in 
+    //    each combination of the first three PCA dimensions 
+    //    in other words dim1xdim2,  dim1xdim3,  dim2xdim3
+    // B) identify peaks in each 2D grid -- each peak corresponds to a section of a PCA code
+    //      A1 is a code snippet representing the first peak of the first grid
+    //      A2 is a code snippet representing the second peak of the first grid  
+    //      B1 is a code snippet representing the first peak of the second grid    
+    //      B0 is a code snippet representing no association with any peak of the second grid
+    //      etc.
+    // C) look at all of the PCA codes of the form
+    //      AhBkCl
+    //    where h, k, and l are non-zero.  Regions of contiguous voxels that share 
+    //    the same code will be designated as the same phase 
+    // D) add voxels that abut any of the contiguous regions to those regions iff
+    //    the code they have matches all code snippet for which they have a non-zero number
+    //    i.e. A0B1C1  is a match for contiguous regions A1B1C1 and A2B1C1
+    public PhaseIdResults GetPhasesStrategyE()
+    {
+        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
+        PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
+
+        float binSeparation = 0.5f;
+        int numDimsToInclude = Math.Min(3, this.scoreDims); // 3 for strategy D
+        Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
+        Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
+
+        // make a dictionary for the pcaCodes and fill with enpty Strings
+        Dictionary<VoxelID, string> pcaCodes = new Dictionary<VoxelID, string>();
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            pcaCodes[voxelId] = "";
+        }
+
+        int AAsciiValue = ASCIIValueForChar('A');
+        int gridIndex = 0;
+        // now, make twoD grids using all pairs of dimensions
+        for (int i = 0; i < (numDimsToInclude - 1); ++i)
+        {
+            for (int j = i + 1; j < numDimsToInclude; ++j)
+            {
+                string gridLetter = CharValueForASCII(AAsciiValue + gridIndex).ToString();
+                string gridId = gridLetter + i.ToString() + "-" + j.ToString();
+
+                // this makes the 2D grid  --  step A) above
+                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
+                twoDGrids[gridId] = twoDGrid;
+
+                // this identifies the peaks --  step B) above
+                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
+                partitions[gridId] = partitionedIndices;
+                DumpPartitions(partitionedIndices, gridId);
+
+                // now label each voxel with a PCA code based on its peak association
+                // for each grid, group the voxels into lists per pixel, then, knowing
+                // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
+                // the PCA code dictionary
+                int peakIndex = 1;
+                Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, i, j);
+                foreach (List<PixelID> pixelIdList in partitionedIndices)
+                {
+                    string pcaCode = gridLetter + "." + peakIndex.ToString();
+                    // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
+                    foreach (PixelID pixelID in pixelIdList)
+                    {
+                        // Lookup for all the voxels bucketed under this pixelId
+                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                        {
+                            pcaCodes[voxelId] = pcaCodes[voxelId] + pcaCode;
+                        }
+                        // remove that entry from voxelLists
+                        voxelLists.Remove(pixelID);
+                    }
+                    peakIndex += 1;
+                }
+
+                // now, all the remaining entries in voxelLists are unassigned :  
+                // assign these to component 0
+                string unassignedPcaCode = gridLetter + ".0";
+                List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
+                foreach (PixelID pixelID in unassignedPixels)
+                {
+                    // Lookup for all the voxels bucketed under this pixelId
+                    List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                    foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                    {
+                        pcaCodes[voxelId] = pcaCodes[voxelId] + unassignedPcaCode;
+                    }
+                }
+
+                var projection = new TwoDPeakProjection(twoDGrid);
+                phaseIdResults.SetTwoDPeakProjectionFor(gridId, projection);
+
+                gridIndex += 1;
+            }
+        }
+
+        // now examine the groups of voxels to identify contiguous regions
+        // in this case, 'unassigned' means voxels not yet associated with a list of voxels in a pcaPhase
+        Dictionary<string, HashSet<VoxelID>> unassignedVoxelBuckets = VoxelBuckets(pcaCodes);
+
+        // first, lets dump some info about populations of all the different 
+        // pca Codes:
+        Dictionary<string, int> pcaCodeCounts = PcaCodeCounts(unassignedVoxelBuckets);
+        DumpPcaCodeCounts(pcaCodeCounts);
+
+        // At this stage we want to identify which voxels are part of contiguous regions of phases
+        // At first, assume that all PCA codes that have no zero value in them identify a particular phase
+        // So, generate a list of voxels for each of these phases 
+
+        List<string> nonZeroPcaCodes = unassignedVoxelBuckets.Keys.Where(code => !code.Contains(".0")).ToList();
+        Dictionary<string, HashSet<VoxelID>> pcaCodeVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
+        // pcaCodes is a Dictionary<VoxelID, string>
+        foreach (string pcaCode in nonZeroPcaCodes)
+        {
+            // just copy over the voxel List to be the base list for  that phase
+            pcaCodeVoxelSets[pcaCode] = unassignedVoxelBuckets[pcaCode];
+            unassignedVoxelBuckets.Remove(pcaCode); 
+        }
+
+        // now pcaCodeVoxelSets is filled with data for each pcaCode,
+        // These are our 'core' regions
+        // now lets go through the voxels with PcaCodes that contain a single 0
+        // and see if they might be adjacent to voxels in any of the core regions  
+        // where that 0 is non-zero
+        // three possibilities:
+        //   1) not adjacent to any
+        //   2) adjacent to voxels sharing a single pcaCode  ( i.e. A1B0C1 adjacent to A1B1C1)
+        //   3) adjacent to voxels of multiple pcaCodes  ( i.e. A1B0C1 adjacent to both A1B1C1 and A1B2C1 voxels)
+        //
+        // for case 1) do nothing
+        // for case 2) add the voxels to the core regions
+        // for case 3) designate the voxel as an interface voxel
+
+        Dictionary<string, HashSet<VoxelID>> unassignedSubtractions = new Dictionary<string, HashSet<VoxelID>>();
+        Dictionary<string, HashSet<VoxelID>> voxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
+        Dictionary<string, HashSet<VoxelID>> interfaceVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
+        Dictionary<string, HashSet<VoxelID>> interfaceVoxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
+        int numNonZeroPcaCodes = nonZeroPcaCodes.Count();
+        for (int nOuter = 0; nOuter < numNonZeroPcaCodes; ++nOuter)
+        {
+            string nonZeroPcaCode = nonZeroPcaCodes[nOuter];
+            voxelSetAdditions[nonZeroPcaCode] = new HashSet<VoxelID>();
+        }
+
+        List<string> unassignedPcaCodes = unassignedVoxelBuckets.Keys.ToList();
+        foreach (string pcaCode in unassignedPcaCodes)
+        {
+            HashSet<string> matchableCodes = filterForMatchableCode(nonZeroPcaCodes, pcaCode);
+            // matchableCodes are the nonZeroPcaCodes that are "one away" from the pcaCode under consideration
+
+            HashSet<VoxelID> potentialAdditions = unassignedVoxelBuckets[pcaCode]; 
+            HashSet<VoxelID> subtractions = new HashSet<VoxelID>();
+            List<string> matches = new List<string>(); 
+            foreach (VoxelID voxelId in potentialAdditions)
+            {
+                List<VoxelID> neighbors = voxelId.NeighborVoxels(gridDims);
+                matches.Clear();
+
+                foreach (string matchingCode in matchableCodes)
+                {
+                    if (pcaCodeVoxelSets[matchingCode].ContainsAny(neighbors))
+                    {
+                        matches.Add(matchingCode);
+                    }
+                }
+
+                // case 1 is no matches 
+                if (matches.Count() > 0)
+                {
+                    if (matches.Count() == 1)
+                    {
+                        voxelSetAdditions[matches[0]].Add(voxelId);
+                        subtractions.Add(voxelId);
+                    }
+                    else
+                    {
+                        string interfaceId = interfaceIdForCodes(matches);
+                        if (interfaceVoxelSetAdditions.ContainsKey(interfaceId))
+                        {
+                            interfaceVoxelSetAdditions[interfaceId].Add(voxelId);
+                        }
+                        else
+                        {
+                            HashSet<VoxelID> newSet = new HashSet<VoxelID>();
+                            newSet.Add(voxelId);
+                            interfaceVoxelSetAdditions[interfaceId] = newSet;
+                        }
+                        subtractions.Add(voxelId);
+                    }
+                }
+            }
+            unassignedSubtractions[pcaCode] = subtractions;
+        }
+        // now, any voxel that is part of interfaceVoxelSetAdditions
+        // or voxelSetAdditions should get taken out of unassignedVoxelBuckets
+        // and added to interfaceVoxelSets or pcaCodeVoxelSets
+        pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
+        pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
+        pcaStream.DumpVoxelSetStats("voxelSetAdditions", voxelSetAdditions);
+        pcaStream.DumpVoxelSetStats("interfaceVoxelSetAdditions", interfaceVoxelSetAdditions);
+        addVoxelsToHashSetDictionary(interfaceVoxelSetAdditions, interfaceVoxelSets);
+        addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
+        subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
+        pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
+        pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
+        pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
+
+        // now, pcaCodeVoxelSets is ready to be used for define a per-voxel component mapping
+        // lets order the pcaCodeVoxelSets by population
+        List<string> pcaCodesByPopulation = pcaCodeVoxelSets.Keys.ToList();
+        PopulationSorter<string, VoxelID> comparator = new PopulationSorter<string, VoxelID>(pcaCodeVoxelSets);
+        pcaCodesByPopulation.Sort(comparator);
+
+        // now pcaCodesByPopulation is sorted?
+        // make a pcaCode to phaseIndex map:
+        // 
+        Dictionary<string, int> phaseIndexMap = new Dictionary<string, int>();
+        int phaseIndex = 1;
+        foreach (string pcaCode in  pcaCodesByPopulation)
+        {
+            phaseIndexMap[pcaCode] = phaseIndex;
+            phaseIndex += 1;
+        }
+
+        // and, call IdentifyVoxelAs for each voxel
+        // phaseResults initializes phase ID to zero for each voxel
+        // So, we only need to assign voxels that have landed in the pcaCodeVoxelSets
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            phaseIdResults.IdentifyVoxelAs(voxelId, 0);
+        }
+            foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in pcaCodeVoxelSets)
+            {
+            string nthPcaCode = kvp.Key;
+            
+            if (phaseIndexMap.ContainsKey(nthPcaCode))
+            {
+                int voxelphase = phaseIndexMap[nthPcaCode];
+                if (voxelphase > 4)
+                {
+                    voxelphase = 6;
+                }
+                foreach(VoxelID voxelId in kvp.Value)
+                {
+                    phaseIdResults.IdentifyVoxelAs(voxelId, voxelphase);
+                }
+            }   
+        }
+
+        // for exery interface voxel, set it to type 5:
+        //  Dictionary<string, HashSet<VoxelID>> interfaceVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
+        foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in interfaceVoxelSets)
+        {
+            foreach (VoxelID voxelId in kvp.Value)
+            {
+                phaseIdResults.IdentifyVoxelAs(voxelId, 5);
+            }
+        }
+
+        pcaStream.Close();
+        return phaseIdResults;
+    }
+
 
     // identifyPartitions use the density map from the twoDGrid to separate 
     // voxels that belong to different peaks in the DensityPlane
@@ -262,7 +879,7 @@ public class PcaScoresGrid
     // If it does, add it to the appropriate list
     // return the list of lists
     // indices not identified are not returned in any list
-    public List<List<PixelID>> IdentifyPartitions(DensityPlane twoDGrid, int dimX, int dimy, List<int> voxelIndices)
+    public List<List<PixelID>> IdentifyPartitions(DensityPlane twoDGrid, int dimX, int dimy)
     {
         // to identify the first maximum, just find the pixel with the highest value
         // then, accumulate neighboring pixels, avoiding neighbors with higher values
@@ -283,13 +900,13 @@ public class PcaScoresGrid
         return pixelLists;
     }
 
-    public DensityPlane CalculateTwoDDensity(List<int> voxelIndices, int dimx, int dimy, float binsize)
+    public DensityPlane CalculateTwoDDensity(List<VoxelID> voxelIds, int dimx, int dimy, float binsize)
     {
         DensityPlane densityPlane = new DensityPlane(binsize);
-        for (int v = 0; v < voxelIndices.Count; ++v)
+        for (int v = 0; v < voxelIds.Count; ++v)
         {
-            int voxelIndex = voxelIndices[v];
-            var voxel = pcaVoxels[voxelIndex];
+            VoxelID voxelId = voxelIds[v];
+            var voxel = pcaVoxels[voxelId];
             var xVal = voxel.scoreVector[dimx];
             var yVal = voxel.scoreVector[dimy];
             densityPlane.AddPointAt(xVal, yVal);
@@ -314,7 +931,7 @@ public class PcaScoresGrid
 	// float binSeparation = 0.5f;
 	// List<DensityProfile> oneDDensities = CalculateOneDDensities(voxelIndices, binSeparation);
 
-    public List<DensityProfile> CalculateOneDDensities(List<int> voxelIndices, float binsize)
+    public List<DensityProfile> CalculateOneDDensities(List<VoxelID> voxelIds, float binsize)
     {
         List<DensityProfile> densities = new List<DensityProfile>();
         for (int i = 0; i < this.scoreDims; ++i)
@@ -323,9 +940,9 @@ public class PcaScoresGrid
             densities.Add(nthDensityList);
         }
 
-        for (int v = 0; v < voxelIndices.Count; ++v)
+        for (int v = 0; v < voxelIds.Count; ++v)
         {
-            int voxelIndex = voxelIndices[v];
+            VoxelID voxelIndex = voxelIds[v];
             var voxel = pcaVoxels[voxelIndex];
             for (int i = 0; i < this.scoreDims; ++i)
             {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -1,0 +1,341 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using System.IO;
+ 
+ 
+// PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
+// PcaScoresGrid is initialized with the size of the grid in x y and z, so that it can then map 
+// a particular [x,y,z] grid coordinate to an index (and back) 
+//
+// Of particular interest to the PCA data processing logic, this class implements the logic for 
+// calculating PhaseIdResults -- using the PCA score data to identify which voxels belong to which 
+// 'phases'
+
+public interface IScoresProvider
+{
+    public float[] GetScores(int voxelIndex);
+}
+public class PcaScoresGrid
+{
+    Dictionary<int, PcaVoxel> pcaVoxels; // the key is the 'id' for the voxel, from which you can
+                                         // calculate the x,y,z position of the voxel on the grid if
+                                         // the grid dimensions are known
+
+    int scoreDims;
+    int xDim;
+    int yDim;
+    int zDim;
+    int nVoxels;
+
+    int VoxelIndexFor(GridCoord gridCoord)
+    {
+        return gridCoord.x + (gridCoord.y * xDim) + (gridCoord.z * xDim * yDim);
+    }
+
+    GridCoord GridCoordFor(int voxelIndex)
+    {
+        int zOffset = xDim * yDim;
+        int yOffset = xDim;
+        int zCoord = voxelIndex / zOffset;
+        int rem = voxelIndex % zOffset;
+        int yCoord = rem / yOffset;
+        rem = rem % yOffset;
+        int xCoord = rem;
+        return new GridCoord(xCoord, yCoord, zCoord);
+    }
+
+    // returns a list of 27 indices, unless the voxel is near the edge
+    List<int> NeighborIndicesFor(GridCoord gridCoord)
+    {
+        List<int> neighborIndices = new List<int>();
+        //List<int> xIndices = new List<int>();
+        //List<int> yIndices = new List<int>();
+        //List<int> zIndices = new List<int>();
+        int minx = Math.Max(0, gridCoord.x - 1);
+        int maxx = Math.Min(xDim - 1, gridCoord.x + 1);
+        int miny = Math.Max(0, gridCoord.y - 1);
+        int maxy = Math.Min(yDim - 1, gridCoord.y + 1);
+        int minz = Math.Max(0, gridCoord.z - 1);
+        int maxz = Math.Min(zDim - 1, gridCoord.z + 1);
+        for (int z = minz; z <= maxz; ++z)
+        {
+            for (int y = miny; y <= maxy; ++y)
+            {
+                for (int x = minx; x <= maxx; ++x)
+                {
+                    neighborIndices.Add(x + (y * xDim) + (z * xDim * yDim));
+                }
+            }
+        }
+        return neighborIndices;
+    }
+    public PcaScoresGrid(IScoresProvider scoresProvider, List<int> voxelIndices, int scoreDimensions, int[] gridDimensions)
+    {
+        scoreDims = scoreDimensions;
+
+        pcaVoxels = pcaVoxelsInit(scoresProvider, voxelIndices, gridDimensions);
+
+        xDim = gridDimensions[0];
+        yDim = gridDimensions[1];
+        zDim = gridDimensions[2];
+
+        nVoxels = xDim * yDim * zDim;
+    }
+
+    static Dictionary<int, PcaVoxel> pcaVoxelsInit(IScoresProvider scoresProvider, List<int> voxelIndices, int[] gridDimensions)
+    {
+        var voxels = new Dictionary<int, PcaVoxel>();
+        int nIndices = voxelIndices.Count;
+
+        for (int i = 0; i < nIndices; ++i)
+        {
+            float[] nthVector = scoresProvider.GetScores(i);
+
+            var pcaVoxel = new PcaVoxel(voxelIndices[i], nthVector);
+            voxels[voxelIndices[i]] = pcaVoxel;
+        }
+
+        return voxels;
+    }
+
+    // GetPhasesStrategyC is produces PhaseIdResults based on the first two 
+    // PCA dimensions only (later strategies will incorporate more dimensions)
+    //
+    // The strategy goes like this:
+    //
+    // A) make a 2D grid representing the density of voxels with PCA scores in 
+    //    the first two PCA dimensions at x,y
+    // B) identify peaks in that 2D grid -- each peak corresponds to a 'phase'
+    // C) assign voxels with PCA scores in each peak to the corresponding phase
+    public PhaseIdResults GetPhasesStrategyC()
+    {
+        List<int> voxelIndices = pcaVoxels.Keys.ToList();
+
+        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIndices, nVoxels);
+
+        float binSeparation = 0.5f;
+        int gridDims = Math.Min(2, this.scoreDims); // 2 is the simplest choice 
+        Dictionary<int, DensityPlane> twoDGrids = new Dictionary<int, DensityPlane>();
+        Dictionary<int, List<List<PixelID>>> partitions = new Dictionary<int, List<List<PixelID>>>();
+        
+        
+        // now, make twoD grids using all pairs of dimensions
+        // yes, GetPhasesStrategyC only uses 2 dimensions, so these loops are useless, 
+        // but they will be used in successive strategies when there are more dimensions used
+        for (int i = 0; i < (gridDims - 1); ++i)
+        {
+            for (int j = i + 1; j < gridDims; ++j)
+            {
+                int gridId = 10 * i + j;
+                
+                // this makes the 2D grid  --  step A) above
+                var twoDGrid = CalculateTwoDDensity(voxelIndices, i, j, binSeparation);
+                twoDGrids[gridId] = twoDGrid;
+                
+                // this identifies the peaks --  step B) above
+                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j, voxelIndices);
+                partitions[gridId] = partitionedIndices;
+            }
+        }
+
+        // now turn the partitions array into the data needed by phaseIDResults -- step C) above
+        // 
+        // phaseIDResults has a method  IdentifyVoxelAs(int voxelIds, int phase)
+        //
+        // a voxel corresponds to the peak if its PCA scores for the given two dimensions 
+        // is in a pixel of a peak. So, for each voxel, we want to call IdentifyVoxelAs()
+        // with the value for 'phase' corresponding to the peak it is in, if any
+        //
+        // to avoid looking up whether or not a pixel is in one of the peaks multiple times,
+        // first, group all the voxelIDs into a list for each pixelID
+        // then do a single lookup for each pixelID
+
+        if (gridDims > 1)
+        {
+            // GetPhasesStrategyC only looks at one grid -- the first one
+            int firstGridId = 1;
+            DensityPlane grid = twoDGrids[firstGridId];
+            List<List<PixelID>> firstGridPartitions = partitions[firstGridId];
+
+            // for debugging, dump the partitions:
+            /* 
+            string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            string outputFilename = System.IO.Path.Combine(docPath, "Partitions.txt");
+
+            using (StreamWriter outputFile = new StreamWriter(outputFilename))
+            {
+                outputFile.WriteLine("partitions file");
+                outputFile.WriteLine("grid Info:");
+
+                TwoDGridCoord gridMinCoord;
+                TwoDGridCoord gridMaxCoord;
+                (gridMinCoord, gridMaxCoord) = grid.MinMaxGridCoords();
+                outputFile.WriteLine("minx: " + gridMinCoord.x);
+                outputFile.WriteLine("miny: " + gridMinCoord.y);
+                outputFile.WriteLine("maxx: " + gridMaxCoord.x);
+                outputFile.WriteLine("maxy: " + gridMaxCoord.y);
+                int peakIndex = 0;
+                outputFile.WriteLine("");
+                foreach (List<PixelID> pixelIdList in firstGridPartitions)
+                {
+                    outputFile.WriteLine("partition: " + peakIndex);
+                    outputFile.WriteLine("pixelCoords: " + peakIndex);
+                    outputFile.Write("{");
+                    foreach (PixelID pixelId in pixelIdList)
+                    {
+                        int x;
+                        int y;
+                        (x, y) = pixelId.xyCoords();
+                        outputFile.Write("{" + x + "," + y + "}");
+                    }
+                    outputFile.Write("}\n");
+                }
+            }
+            */
+            // end of debug dump
+            
+            // For each voxel, assign the voxel to the List corresponding with its pixel
+            Dictionary<PixelID, List<int>> voxelLists = new Dictionary<PixelID, List<int>>();
+            foreach (int voxelId in voxelIndices)
+            {
+                PcaVoxel voxel = pcaVoxels[voxelId];
+                PixelID nthPixelId = grid.PixelIDFor(voxel.scoreVector[0], voxel.scoreVector[1]);
+                List<int>? voxelIDListForGridCoord;
+                if (voxelLists.TryGetValue(nthPixelId, out voxelIDListForGridCoord))
+                {
+                    voxelIDListForGridCoord.Add(voxelId);
+                }
+                else
+                {
+                    voxelIDListForGridCoord = new List<int>();
+                    voxelIDListForGridCoord.Add(voxelId);
+                    voxelLists[nthPixelId] = voxelIDListForGridCoord;
+                }
+            }
+
+            // now, each voxelIndex is a member of one of the lists in voxelLists
+            // go through each list in voxelLists and see if its pixel is designated in a particular partiion
+            // that is, for each pixel, see which peak it belongs to, if any
+             
+            int listN = 1;
+            foreach (List<PixelID> pixelIdList in firstGridPartitions)
+            {
+                // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
+                foreach (PixelID pixelID in pixelIdList)
+                {
+                    // Lookup for all the voxels bucketed under this pixelId
+                    List<int> voxelIds = voxelLists[pixelID];
+                    foreach (int voxelId in voxelIds)
+                    {
+                        phaseIdResults.IdentifyVoxelAs(voxelId, listN);
+                    }
+                    // remove that entry from voxelLists
+                    voxelLists.Remove(pixelID);
+                }
+
+                ++listN;
+            }
+
+            // now, all the remaining entries in voxelLists are unassigned :  
+            // assign these to component 0
+            List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
+            foreach (PixelID pixelID in unassignedPixels)
+            {
+                // Lookup for all the voxels bucketed under this pixelId
+                List<int> voxelIds = voxelLists[pixelID];
+                foreach (int voxelId in voxelIds)
+                {
+                    phaseIdResults.IdentifyVoxelAs(voxelId, 0);
+                }
+            }
+        }
+
+        return phaseIdResults;
+    }
+
+    // identifyPartitions use the density map from the twoDGrid to separate 
+    // voxels that belong to different peaks in the DensityPlane
+    // first, identify the peaks and their associated pixels
+    // then, for each voxel, see if it lands in on of the partitioned pixels.
+    // If it does, add it to the appropriate list
+    // return the list of lists
+    // indices not identified are not returned in any list
+    public List<List<PixelID>> IdentifyPartitions(DensityPlane twoDGrid, int dimX, int dimy, List<int> voxelIndices)
+    {
+        // to identify the first maximum, just find the pixel with the highest value
+        // then, accumulate neighboring pixels, avoiding neighbors with higher values
+        // accumulate neighbors in order of their density value.
+        // stop accumulating when a slope increase is found:
+        //   this indicates there must be another maximum to look for
+        // also, stop at 10% of peak max
+        // to look for another maximum, find the remaining pixel with the maximum value.
+        // continue accumulating pixels into all peaks
+
+        // partitionFinder operates on the grid, identifying pixels
+        // associated with the different maxima
+        TwoDGridPartitionFinder partitionFinder = new TwoDGridPartitionFinder(twoDGrid);
+
+        partitionFinder.FindPartitions(0.1f);
+        var pixelLists = partitionFinder.GetPixelLists();
+        partitionFinder.Clear();
+        return pixelLists;
+    }
+
+    public DensityPlane CalculateTwoDDensity(List<int> voxelIndices, int dimx, int dimy, float binsize)
+    {
+        DensityPlane densityPlane = new DensityPlane(binsize);
+        for (int v = 0; v < voxelIndices.Count; ++v)
+        {
+            int voxelIndex = voxelIndices[v];
+            var voxel = pcaVoxels[voxelIndex];
+            var xVal = voxel.scoreVector[dimx];
+            var yVal = voxel.scoreVector[dimy];
+            densityPlane.AddPointAt(xVal, yVal);
+        }
+        return densityPlane;
+    }
+
+    // CalculateOneDDensities is not used, but here's what it does:
+	// it creates a profile along each of the principal PCA dimensions 
+	// of the density of voxels along that dimension 
+	// That is, peaks in the density profile represent PCA score values with a high population of 
+	// voxels. each Profile is a 'smoothed' histogram of populations 
+	// The AP Suite already has code that produces a similar histogram, displayed
+	// in one of the panes of the PCA Extension.
+	// 
+	// The number of points in the profile is determined by the binsize
+	// If there are points between 0 and 10, there may be 23 entries, from -0.5 to 10.5
+	// at spacings of 0.5
+	//
+	// It can be used like this:
+	//
+	// float binSeparation = 0.5f;
+	// List<DensityProfile> oneDDensities = CalculateOneDDensities(voxelIndices, binSeparation);
+
+    public List<DensityProfile> CalculateOneDDensities(List<int> voxelIndices, float binsize)
+    {
+        List<DensityProfile> densities = new List<DensityProfile>();
+        for (int i = 0; i < this.scoreDims; ++i)
+        {
+            var nthDensityList = new DensityProfile(binsize);
+            densities.Add(nthDensityList);
+        }
+
+        for (int v = 0; v < voxelIndices.Count; ++v)
+        {
+            int voxelIndex = voxelIndices[v];
+            var voxel = pcaVoxels[voxelIndex];
+            for (int i = 0; i < this.scoreDims; ++i)
+            {
+                densities[i].AddPointAt(voxel.scoreVector[i]);
+            }
+        }
+        return densities;
+    }
+}
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -186,144 +186,6 @@ public class PcaScoresGrid
         }
     }
 
-    // GetPhasesStrategyC is produces PhaseIdResults based on the first two 
-    // PCA dimensions only (later strategies will incorporate more dimensions)
-    //
-    // The strategy goes like this:
-    //
-    // A) make a 2D grid representing the density of voxels with PCA scores in 
-    //    the first two PCA dimensions at x,y
-    // B) identify peaks in that 2D grid -- each peak corresponds to a 'phase'
-    // C) assign voxels with PCA scores in each peak to the corresponding phase
-    public PhaseIdResults GetPhasesStrategyC()
-    {
-        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
-
-        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
-
-        float binSeparation = 0.5f;
-        int gridDims = Math.Min(2, this.scoreDims); // 2 is the simplest choice 
-        Dictionary<int, DensityPlane> twoDGrids = new Dictionary<int, DensityPlane>();
-        Dictionary<int, List<List<PixelID>>> partitions = new Dictionary<int, List<List<PixelID>>>();
-
-        // now, make twoD grids using all pairs of dimensions
-        // yes, GetPhasesStrategyC only uses 2 dimensions, so these loops are useless, 
-        // but they will be used in successive strategies when there are more dimensions used
-        for (int i = 0; i < (gridDims - 1); ++i)
-        {
-            for (int j = i + 1; j < gridDims; ++j)
-            {
-                int gridId = 10 * i + j;
-
-                // this makes the 2D grid  --  step A) above
-                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
-                twoDGrids[gridId] = twoDGrid;
-
-                // this identifies the peaks --  step B) above
-                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
-
-                partitions[gridId] = partitionedIndices;
-            }
-        }
-
-        // now turn the partitions array into the data needed by phaseIDResults -- step C) above
-        // 
-        // phaseIDResults has a method  IdentifyVoxelAs(int voxelIds, int phase)
-        //
-        // a voxel corresponds to the peak if its PCA scores for the given two dimensions 
-        // is in a pixel of a peak. So, for each voxel, we want to call IdentifyVoxelAs()
-        // with the value for 'phase' corresponding to the peak it is in, if any
-        //
-        // to avoid looking up whether or not a pixel is in one of the peaks multiple times,
-        // first, group all the voxelIDs into a list for each pixelID
-        // then do a single lookup for each pixelID
-
-        if (gridDims > 1)
-        {
-            // GetPhasesStrategyC only looks at one grid -- the first one
-            int firstGridId = 1;
-            DensityPlane grid = twoDGrids[firstGridId];
-            List<List<PixelID>> firstGridPartitions = partitions[firstGridId];
-
-            // for debugging, dump the partitions:
-            /* 
-            string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            string outputFilename = System.IO.Path.Combine(docPath, "Partitions.txt");
-
-            using (StreamWriter outputFile = new StreamWriter(outputFilename))
-            {
-                outputFile.WriteLine("partitions file");
-                outputFile.WriteLine("grid Info:");
-
-                TwoDGridCoord gridMinCoord;
-                TwoDGridCoord gridMaxCoord;
-                (gridMinCoord, gridMaxCoord) = grid.MinMaxGridCoords();
-                outputFile.WriteLine("minx: " + gridMinCoord.x);
-                outputFile.WriteLine("miny: " + gridMinCoord.y);
-                outputFile.WriteLine("maxx: " + gridMaxCoord.x);
-                outputFile.WriteLine("maxy: " + gridMaxCoord.y);
-                int peakIndex = 0;
-                outputFile.WriteLine("");
-                foreach (List<PixelID> pixelIdList in firstGridPartitions)
-                {
-                    outputFile.WriteLine("partition: " + peakIndex);
-                    outputFile.WriteLine("pixelCoords: " + peakIndex);
-                    outputFile.Write("{");
-                    foreach (PixelID pixelId in pixelIdList)
-                    {
-                        int x;
-                        int y;
-                        (x, y) = pixelId.xyCoords();
-                        outputFile.Write("{" + x + "," + y + "}");
-                    }
-                    outputFile.Write("}\n");
-                }
-            }
-            */
-            // end of debug dump
-
-            Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, grid, pcaVoxels, 0, 1);
-
-            // now, each voxelIndex is a member of one of the lists in voxelLists
-            // go through each list in voxelLists and see if its pixel is designated in a particular partiion
-            // that is, for each pixel, see which peak it belongs to, if any
-
-            int listN = 1;
-            foreach (List<PixelID> pixelIdList in firstGridPartitions)
-            {
-                // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
-                foreach (PixelID pixelID in pixelIdList)
-                {
-                    // Lookup for all the voxels bucketed under this pixelId
-                    List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                    foreach (VoxelID voxelId in voxelIdsForThisPixel)
-
-                    {
-                        phaseIdResults.IdentifyVoxelAs(voxelId, listN);
-                    }
-                    // remove that entry from voxelLists
-                    voxelLists.Remove(pixelID);
-                }
-
-                ++listN;
-            }
-
-            // now, all the remaining entries in voxelLists are unassigned :  
-            // assign these to component 0
-            List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
-            foreach (PixelID pixelID in unassignedPixels)
-            {
-                // Lookup for all the voxels bucketed under this pixelId
-                List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                foreach (VoxelID voxelId in voxelIdsForThisPixel)
-                {
-                    phaseIdResults.IdentifyVoxelAs(voxelId, 0);
-                }
-            }
-        }
-
-        return phaseIdResults;
-    }
     internal void DumpPartitions(List<List<PixelID>> partitions, string gridId)
     {
         string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
@@ -364,145 +226,6 @@ public class PcaScoresGrid
             outputFile.Write("}");
             outputFile.Close();
         }
-    }
-    // GetPhasesStrategyD is produces PhaseIdResults based on the first three 
-    // PCA dimensions only  
-    //
-    // The strategy goes like this:
-    //
-    // A) make three 2D grids representing the density of voxels with PCA scores in 
-    //    each combination of the first three PCA dimensions 
-    //    in other words dim1xdim2,  dim1xdim3,  dim2xdim3
-    // B) identify peaks in each 2D grid -- each peak corresponds to a section of a PCA code
-    //      A1 is a code snippet representing the first peak of the first grid
-    //      A2 is a code snippet representing the second peak of the first grid  
-    //      B1 is a code snippet representing the first peak of the second grid    
-    //      B0 is a code snippet representing no association with any peak of the second grid
-    //      etc.
-    // C) identify the top 4 buckets and assign those to phases
-    //      assign all the rest to phase 0
-    //  note -- steps A and B are identical  to GetPhasesStrategyD
-    //          step C is just a shortcut to identifying phases to make sure the code was working
-    public PhaseIdResults GetPhasesStrategyD()
-    {
-        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
-
-        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
-
-        float binSeparation = 0.5f;
-        int gridDims = Math.Min(3, this.scoreDims); // 3 for strategy D
-        Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
-        Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
-
-        // make a dictionary for the pcaCodes and fill with enpty Strings
-        Dictionary<VoxelID, string> pcaCodes = new Dictionary<VoxelID, string>();
-        foreach (VoxelID voxelId in voxelIds)
-        {
-            pcaCodes[voxelId] = "";
-        }
-
-        int AAsciiValue = ASCIIValueForChar('A');
-        int gridIndex = 0;
-        // now, make twoD grids using all pairs of dimensions
-        for (int i = 0; i < (gridDims - 1); ++i)
-        {
-            for (int j = i + 1; j < gridDims; ++j)
-            {
-                string gridLetter = CharValueForASCII(AAsciiValue + gridIndex).ToString();
-                string gridId = gridLetter + i.ToString() + j.ToString();
-
-                // this makes the 2D grid  --  step A) above
-                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
-                twoDGrids[gridId] = twoDGrid;
-
-                // this identifies the peaks --  step B) above
-                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
-                partitions[gridId] = partitionedIndices;
-                DumpPartitions(partitionedIndices, gridId);
-
-                // now label each voxel with a PCA code based on its peak association
-                // for each grid, group the voxels into lists per pixel, then, knowing
-                // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
-                // the PCA code dictionary
-                int peakIndex = 1;
-                Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, i, j);
-                foreach (List<PixelID> pixelIdList in partitionedIndices)
-                {
-                    string pcaCode = gridLetter + "." + peakIndex.ToString();
-                    // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
-                    foreach (PixelID pixelID in pixelIdList)
-                    {
-                        // Lookup for all the voxels bucketed under this pixelId
-                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
-                        {
-                            pcaCodes[voxelId] = pcaCodes[voxelId] + pcaCode;
-                        }
-                        // remove that entry from voxelLists
-                        voxelLists.Remove(pixelID);
-                    }
-                    peakIndex += 1;
-                }
-
-                // now, all the remaining entries in voxelLists are unassigned :  
-                // assign these to component 0
-                string unassignedPcaCode = gridLetter + ".0";
-                List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
-                foreach (PixelID pixelID in unassignedPixels)
-                {
-                    // Lookup for all the voxels bucketed under this pixelId
-                    List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                    foreach (VoxelID voxelId in voxelIdsForThisPixel)
-                    {
-                        pcaCodes[voxelId] = pcaCodes[voxelId] + unassignedPcaCode;
-                    }
-                }
-                gridIndex += 1;
-            }
-        }
-
-        // now examine the groups of voxels to identify contiguous regions
-        // first, lets dump some info about populations of all the different 
-        // pca Codes:
-        Dictionary<string, HashSet<VoxelID>> voxelBuckets = VoxelBuckets(pcaCodes);
-
-        // first, lets dump some info about populations of all the different 
-        // pca Codes:
-        Dictionary<string, int> pcaCodeCounts = PcaCodeCounts(voxelBuckets);
-        DumpPcaCodeCounts(pcaCodeCounts);
-
-
-        // preliminary strategy D:
-        // just find the highest populated 4 buckets in pcaCodeCounts, assign those as 
-        // the first 4 components
-        // leave the voxel coagulation until later
-
-        // phaseIDResults has a method  IdentifyVoxelAs(int voxelIds, int phase)
-        List<KeyValuePair<string, int>> kvpList = pcaCodeCounts.ToList<KeyValuePair<string, int>>();
-        List<KeyValuePair<string, int>> sortedKvpList = kvpList.OrderByDescending(kvp => kvp.Value).ToList();
-        Dictionary<string, int> phaseAssignments = new Dictionary<string, int>();
-        int phase = 1;
-        foreach (KeyValuePair<string, int> kvp in sortedKvpList)
-        {
-            phaseAssignments[kvp.Key] = phase;
-            phase += 1;
-        }
-
-        // and, call IdentifyVoxelAs for each voxel
-        // now, all the remaining entries in voxelLists are unassigned :  
-        // assign these to component 0
-        foreach (VoxelID voxelId in voxelIds)
-        {
-            string pcaCode = pcaCodes[voxelId];
-            int voxelphase = phaseAssignments[pcaCode];
-            if (voxelphase > 4)
-            {
-                voxelphase = 0;
-            }
-
-            phaseIdResults.IdentifyVoxelAs(voxelId, voxelphase);
-        }
-        return phaseIdResults;
     }
 
     internal List<VoxelID> FindMatchingSets(VoxelID neighborID, Dictionary<VoxelID, HashSet<VoxelID>> voxelSets)
@@ -625,7 +348,11 @@ public class PcaScoresGrid
     public PhaseIdResults GetPhasesStrategyE()
     {
         List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
-        PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+
+        // PcaStream writes a file with text data about the progression of the algorithm
+        // uncomment it here and uncomment the calls to DumpVoxelSetStats below
+        // PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+
         PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
         float binSeparation = 0.5f;
@@ -657,7 +384,9 @@ public class PcaScoresGrid
                 // this identifies the peaks --  step B) above
                 List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
                 partitions[gridId] = partitionedIndices;
-                DumpPartitions(partitionedIndices, gridId);
+
+                // Enable this to get a text file with partition data
+                // DumpPartitions(partitionedIndices, gridId);
 
                 // now label each voxel with a PCA code based on its peak association
                 // for each grid, group the voxels into lists per pixel, then, knowing
@@ -711,7 +440,9 @@ public class PcaScoresGrid
         // first, lets dump some info about populations of all the different 
         // pca Codes:
         Dictionary<string, int> pcaCodeCounts = PcaCodeCounts(unassignedVoxelBuckets);
-        DumpPcaCodeCounts(pcaCodeCounts);
+
+        // Enable this line to get a text file with counts of the different buckets
+        //DumpPcaCodeCounts(pcaCodeCounts);
 
         // At this stage we want to identify which voxels are part of contiguous regions of phases
         // At first, assume that all PCA codes that have no zero value in them identify a particular phase
@@ -804,16 +535,21 @@ public class PcaScoresGrid
         // now, any voxel that is part of interfaceVoxelSetAdditions
         // or voxelSetAdditions should get taken out of unassignedVoxelBuckets
         // and added to interfaceVoxelSets or pcaCodeVoxelSets
-        pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
-        pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
-        pcaStream.DumpVoxelSetStats("voxelSetAdditions", voxelSetAdditions);
-        pcaStream.DumpVoxelSetStats("interfaceVoxelSetAdditions", interfaceVoxelSetAdditions);
+
+        // calls to DumpVoxelSetStats are used to follow the progression of the algorithm is assigning voxels
+        // these can be enabled if the pcaStream object is created above
+        // pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
+        // pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
+        // pcaStream.DumpVoxelSetStats("voxelSetAdditions", voxelSetAdditions);
+        // pcaStream.DumpVoxelSetStats("interfaceVoxelSetAdditions", interfaceVoxelSetAdditions);
+
         addVoxelsToHashSetDictionary(interfaceVoxelSetAdditions, interfaceVoxelSets);
         addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
         subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
-        pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
-        pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
-        pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
+
+        // pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
+        // pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
+        // pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
 
         // now, pcaCodeVoxelSets is ready to be used for define a per-voxel component mapping
         // lets order the pcaCodeVoxelSets by population
@@ -867,7 +603,7 @@ public class PcaScoresGrid
             }
         }
 
-        pcaStream.Close();
+        // pcaStream.Close();
         return phaseIdResults;
     }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaStream.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaStream.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using System.IO;
+using Cameca.CustomAnalysis.Interface;
+using System.DirectoryServices.ActiveDirectory;
+
+// PcaStream is a utility class for writing information to a file during a run of the 
+// Pca code in APSuite
+// On creation of the object, a unique name is chosen based on timestamp.
+// 
+
+public class PcaStream  
+{
+    StreamWriter outputFile;
+    DateTime creationTime;
+
+    public void DumpVoxelSetStats(string prefix, Dictionary<string, HashSet<VoxelID>> voxelSets)
+    {
+        outputFile.WriteLine(prefix);
+        foreach(KeyValuePair<string, HashSet<VoxelID>> kvp in voxelSets)
+        {
+            outputFile.WriteLine(kvp.Key + ": " + kvp.Value.Count());
+        }
+        outputFile.WriteLine("!");
+    }
+
+    // for use in filename, can't use : -- replace those with -
+    // Using the format string "s" results in a string like this 2008-06-15T21:15:07
+    static string DateAsString(DateTime dt)
+    { 
+        string s = dt.ToString("s");
+        return s.Replace(":", "-");
+    }
+
+    public PcaStream(string fileNameStem)
+    {
+        string docPath = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+        creationTime = DateTime.Now;
+        string filename = fileNameStem + "-" + DateAsString(creationTime);
+        string outputFilename = System.IO.Path.Combine(docPath, filename);
+
+        outputFile = new StreamWriter(outputFilename);
+    }
+
+    public void WriteTimestamp(string prefix)
+    {
+        DateTime dtNow = DateTime.Now;
+        TimeSpan diff = dtNow - creationTime;
+        outputFile.WriteLine(prefix + " timestamp " +  diff.ToString());
+    }
+
+    public void Close()
+    {
+        outputFile.Close();
+    }
+} 
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using Prism.Regions;
+using System.Runtime.CompilerServices;
+using System.Windows.Documents;
+using System.Security.Cryptography;
+using System.Windows.Input;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+using System.Xml.Schema;
+using Cameca.CustomAnalysis.Interface;
+
+// PcaVoxel represents a voxel and its PCA scores returned from the PCA algorithm
+public struct PcaVoxel
+{
+    public int voxelIndex; // the voxelIndex from compResults.VoxelIndices;  (between 0 and nTotalVoxels - 1)
+    public float[] scoreVector;
+
+    public PcaVoxel(int vIndex, float[] vec)
+    {
+        voxelIndex = vIndex;
+        scoreVector = vec;
+    }
+}
+
+ 
+
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
@@ -12,15 +12,105 @@ using System.IO;
 using System.Xml.Schema;
 using Cameca.CustomAnalysis.Interface;
 
+public struct VoxelID : IComparable<VoxelID>
+{
+
+    public int intValue;
+
+    public VoxelID(int voxelId)
+    {
+        this.intValue = voxelId;
+    }
+
+    public VoxelID(ThreeDGridDimensions dims, int x, int y, int z)
+    {
+        this.intValue = dims.VoxelIdIntValueFor(x, y, z);
+    }
+
+    static VoxelID? VoxelIDIfPossible(ThreeDGridDimensions dims, int x, int y, int z)
+    {
+        if (dims.VoxelExists(x, y, z))
+        {
+            return new VoxelID(dims, x, y, z);
+        }
+        return null;
+    }
+    static public List<VoxelID> ListFromIntArray(int[] integerIds)
+    {
+        List<VoxelID> newList = new List<VoxelID>();
+        foreach(int n in integerIds)
+        {
+            newList.Add(new VoxelID(n));
+        }
+        return newList;
+    }
+
+    public (int, int, int) xyzCoordsFor(ThreeDGridDimensions dims)
+    {
+        int zOffset = dims.xy;
+        int yOffset = dims.x;
+        int zCoord = this.intValue / zOffset;
+        int rem = this.intValue % zOffset;
+        int yCoord = rem / yOffset;
+        rem = rem % yOffset;
+        int xCoord = rem;
+        return (xCoord, yCoord, zCoord);
+    }
+
+    public ThreeDGridCoord GridCoordFor(ThreeDGridDimensions dims)
+    {
+        int z = 0;
+        int y = 0;
+        int x = 0;
+        (x, y, z) = xyzCoordsFor(dims);
+        return new ThreeDGridCoord(x, y, z);
+    }
+
+    public int CompareTo(VoxelID other)
+    {
+        return other.intValue > intValue ? -1 : other.intValue < intValue ? 1 : 0;
+    }
+
+    internal void AddIfPossible(int x, int y, int z, ThreeDGridDimensions dims, List<VoxelID> neighbors)
+    {
+        VoxelID? voxelId = VoxelID.VoxelIDIfPossible(dims, x, y, z);
+        if (voxelId != null)
+        {
+            neighbors.Add(voxelId.Value);
+        }
+    }
+    public List<VoxelID> NeighborVoxels(ThreeDGridDimensions dims)
+    {
+        (int x, int y, int z) = this.xyzCoordsFor(dims);
+        List<VoxelID> neighbors = new List<VoxelID>();
+        AddIfPossible(x - 1, y, z, dims, neighbors);
+        AddIfPossible(x + 1, y, z, dims, neighbors);
+        AddIfPossible(x, y - 1, z, dims, neighbors);
+        AddIfPossible(x, y + 1, z, dims, neighbors);
+        AddIfPossible(x, y, z - 1, dims, neighbors);
+        AddIfPossible(x, y, z + 1, dims, neighbors);
+        return neighbors;
+    }
+
+    public string DebugStr(ThreeDGridDimensions dims)
+    {
+        int z;
+        int y;
+        int x;
+        (x, y, z) = xyzCoordsFor(dims);
+        return intValue.ToString() + ":{" + x + "," + y + " + " + z + "}";
+    }
+}
+
 // PcaVoxel represents a voxel and its PCA scores returned from the PCA algorithm
 public struct PcaVoxel
 {
-    public int voxelIndex; // the voxelIndex from compResults.VoxelIndices;  (between 0 and nTotalVoxels - 1)
+    public VoxelID voxelId; // the voxelIndex from compResults.VoxelIndices;  (between 0 and nTotalVoxels - 1)
     public float[] scoreVector;
 
-    public PcaVoxel(int vIndex, float[] vec)
+    public PcaVoxel(VoxelID vId, float[] vec)
     {
-        voxelIndex = vIndex;
+        voxelId = vId;
         scoreVector = vec;
     }
 }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PopulationSorter.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PopulationSorter.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using System.IO;
+
+
+
+public class PopulationSorter<T, U> : IComparer<T>
+{
+    Dictionary<T, HashSet<U>> dict;
+    public PopulationSorter(Dictionary<T, HashSet<U>> d)
+    {
+        dict = d;
+    }
+
+    public int Compare(T? x, T? y)
+    {
+        int popX = 0;
+        int popY = 0;
+        if (x != null && dict.ContainsKey(x))
+        {
+            popX = dict[x].Count();
+        }
+        if (y != null && dict.ContainsKey(y))
+        {
+            popY = dict[y].Count();
+        }
+        return (popX > popY) ? -1 : (popY > popX) ? 1 : 0;
+    }
+ 
+}
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -229,7 +229,6 @@ public class TwoDGridPartitionFinder
                     }
                 case ReturnCode.foundIncrease:
                     {
-                        Debug.Write("returnCode found increase");
                             // need to remove the 'found increase' buckets from the peaks;
                             // also, collect these so that we can remember to look for new peaks
                         foreach (PeakID peakId in peaks.Keys.ToList())

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using PcaExtensionMethods;
+
+
+public class TwoDGridPartitionFinder
+{
+    DensityPlane grid;
+    List<PixelID> unplacedPixelIds;
+    List<PixelID> rejectedPixelIds;
+    List<PixelID> foundIncreasePixelIds; // when a peak finds an increase, remember it here
+    Dictionary<PeakID, TwoDPeak> peaks;
+
+    // These are the return codes returned by IterateIdentifyingPeaks()
+    // Depending on this result, the Logic in FindPartitions will either
+    // seach for a new peak, or lower the search floor parameter provided to 
+    // IterateIdentifyingPeaks()
+    public enum ReturnCode {
+        noStatus,
+        foundIncrease,
+        bestSuggestionBelowFloor,
+        exhaustedSuggestions
+    }
+
+    public TwoDGridPartitionFinder(DensityPlane twoDGrid)
+    {
+        this.grid = twoDGrid;
+        this.peaks = new Dictionary<PeakID, TwoDPeak> ();
+        this.rejectedPixelIds = new List<PixelID>();
+        this.foundIncreasePixelIds = new List<PixelID>();
+        this.unplacedPixelIds = twoDGrid.GridPointIds();
+    }
+
+    // for each iteration step,
+    // 1) ask the different peaks if they have found an increase
+    //    if yes -- make new peak, otherwise
+    // 2) ask the different peaks to suggest 
+    //    their next target pixel(s)
+    // 3) find highest valued pixel(s)
+    // 4) reject pixels that collide
+    //    -- notify each peak of rejection
+    //    -- place rejected pixels in rejected bucket
+    //    -- remove from unplacedPixelIds
+    // 5) stop if highest valued pixel is below floor
+    // 6) accept all highest valued pixels
+    //    -- notify each peak of acceptance and
+    //    -- remove from unplacedPixelIds
+
+    public ReturnCode IterateIdentifyingPeaks(float noiseFloor)
+    {
+        bool keepGoing = true;
+        ReturnCode returnCode = ReturnCode.noStatus;
+        while (keepGoing)
+        {
+            CandidateRanker candidateRanker = new CandidateRanker();
+
+            //step 1
+            foreach (PeakID peakKey in peaks.Keys.ToList())
+            {
+                TwoDPeak nthPeak = peaks[peakKey];
+                if (nthPeak.HasFoundIncrease()) {
+                    // need to clean out the 'HasFoundIncrease' flag from the peaks
+                    // this will get done by the caller if we return the 'found increase' flag
+                    return ReturnCode.foundIncrease; 
+                }
+            }
+
+            // step 2
+            candidateRanker.Clear();
+            foreach (PeakID peakKey in peaks.Keys.ToList())
+            {
+                TwoDPeak nthPeak = peaks[peakKey];
+                var nthSuggestions = nthPeak.NextSuggestions();
+                foreach (PixelSuggestion nthSuggestion in nthSuggestions)
+                {
+                    candidateRanker.Consider(nthSuggestion);
+                }
+            }
+
+            // step 3
+            List<PixelSuggestion> bestCandidates = candidateRanker.bestCandidates();
+            if (bestCandidates.Count == 0)
+            {
+                return ReturnCode.exhaustedSuggestions;
+            }
+
+            // step 4
+            // count all the instances of each ID
+            Dictionary<PixelID, int> pixelIdCounts = new Dictionary<PixelID, int>();
+            foreach (PixelSuggestion suggestion in bestCandidates)
+            {
+                if (pixelIdCounts.ContainsKey(suggestion.pixelId))
+                {
+                    pixelIdCounts[suggestion.pixelId] = pixelIdCounts[suggestion.pixelId] + 1;
+                }
+                else
+                {
+                    pixelIdCounts[suggestion.pixelId] = 1;
+                }
+            }
+            // if there are any elements of the pixelIdCounts dictionary with value more than 1,
+            // that's a collision
+
+            List<PixelID> collisions = new List<PixelID>();
+            List<PixelID> pixelIdCountsKeys = pixelIdCounts.Keys.ToList();
+            foreach (PixelID pixelId in pixelIdCountsKeys)
+            {
+                if (pixelIdCounts[pixelId] > 1)
+                {
+                    collisions.Add(pixelId);
+                }
+            }
+
+            // foreach (PixelID collidingPixelId in collisions)
+            if (collisions.Count > 0)
+            {
+                List<PixelSuggestion> tempCandidates = bestCandidates;
+                bestCandidates = new List<PixelSuggestion>();
+                // remove the collisions from bestCandidates
+                // add the ids to rejectedPixelIds
+                // notify peaks of rejection
+
+                foreach (PixelSuggestion suggestion in tempCandidates)
+                {
+                    if (collisions.Contains(suggestion.pixelId))
+                    {
+                        peaks[suggestion.peakId].SuggestionRejected(suggestion);
+                    }
+                    else
+                    {
+                        bestCandidates.Add(suggestion);
+                    }
+                }
+
+                foreach (PixelID pixelId in collisions)
+                {
+                    rejectedPixelIds.Add(pixelId);
+                    unplacedPixelIds.Remove(pixelId);
+                }
+            }
+
+
+            // step 6
+            // for each accepted suggestion, notify the peak of Acceptance,
+            // remove the id from unplaced IDs
+
+            foreach (PixelSuggestion suggestion in bestCandidates)
+            {
+                // step 5 -- make sure the score is above the floor
+                if (suggestion.score < noiseFloor)
+                {
+                    returnCode = ReturnCode.bestSuggestionBelowFloor;
+                    keepGoing = false;
+                }
+                else
+                {
+                    peaks[suggestion.peakId].SuggestionAccepted(suggestion);
+                    unplacedPixelIds.Remove(suggestion.pixelId);
+                }
+            }
+        }
+        return returnCode;
+    }
+
+
+    public void Clear()
+    {
+        peaks.Clear();
+        rejectedPixelIds.Clear();
+        unplacedPixelIds.Clear();
+        unplacedPixelIds = grid.GridPointIds();
+    }
+
+    public List<List<PixelID>> GetPixelLists()
+    {
+        List<List<PixelID>> pixelLists = new List<List<PixelID>>();
+        foreach (PeakID peakKey in peaks.Keys.ToList())
+        {
+            TwoDPeak nthPeak = peaks[peakKey];
+            List<PixelID> peakPixelList = nthPeak.PixelList();
+            pixelLists.Add(peakPixelList);
+        }
+        return pixelLists;
+    }
+
+    // FindPartitions sets up the initial conditions for identifying peaks in the DensityPlane
+    // and calls IterateIdentifyingPeaks() to do most of the work
+    //
+    // each time it calls IterateIdentifyingPeaks() it provides a floor for values to look for
+    // The initial search floor is essentially a cutoff for how much of the peak to accept
+    // Initially it is tied here to the 10% of the value of the highest peak (the noise floor fraction)
+    //   -- this will be a good parameter to expose to users.
+    // However, the search floor is also set when the algorithm knows that higher peak must exist 
+    // above a certain value (because it found a pixel not connected to an existing peak with a higher value)
+    // When this happens, the algorithm searches for another peak and its related pixels
+    // As long as the pixel it found is not in fact part of new peak, the algorithm knows it should 
+    // look for another peak
+    public void FindPartitions(float noiseFloorFraction)
+    {
+        float noiseFloor = grid.MaximumValue(unplacedPixelIds) * noiseFloorFraction;
+        PixelID? maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
+        bool shouldContinueWithLowerSearchFloor = false;
+        while (maybeMaximumPixelId.HasValue || shouldContinueWithLowerSearchFloor)
+        {
+            if (!shouldContinueWithLowerSearchFloor && maybeMaximumPixelId.HasValue)
+            {
+                PixelID maximumPixelId = maybeMaximumPixelId.Value;
+                TwoDPeak nextPeak = new TwoDPeak(this, grid, maximumPixelId);
+                peaks[nextPeak.peakId] = nextPeak;
+            }
+
+            shouldContinueWithLowerSearchFloor = false;
+            float higherPixelVal = 0.0f;
+            if (foundIncreasePixelIds.Count > 0)
+            {
+                higherPixelVal = grid.valueAtPixel(foundIncreasePixelIds[0]);
+            }
+            float searchFloor = Math.Max(higherPixelVal, noiseFloor);
+            ReturnCode returnCode = IterateIdentifyingPeaks(searchFloor);
+
+            switch (returnCode)
+            {
+                case ReturnCode.noStatus:
+                    {
+                        Debug.Write("returnCode noStatus -- must be error");
+                        break;
+                    }
+                case ReturnCode.foundIncrease:
+                    {
+                        Debug.Write("returnCode found increase");
+                            // need to remove the 'found increase' buckets from the peaks;
+                            // also, collect these so that we can remember to look for new peaks
+                        foreach (PeakID peakId in peaks.Keys.ToList())
+                        {
+                            List<PixelID> higherPixels = peaks[peakId].ClearFoundIncreases();
+                            foreach (PixelID pixelId in higherPixels)
+                            {
+                                foundIncreasePixelIds.AddSorted(pixelId);
+                            }
+                        }
+                        maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
+                        break;
+                    }
+                case ReturnCode.bestSuggestionBelowFloor:
+                    {
+                        // its possible we have another peak to find
+                        // first. filter any previous identified higherPixels to see if they are now part of a new peak:
+                        foundIncreasePixelIds = filterForAvailableIds(foundIncreasePixelIds);
+                        if (foundIncreasePixelIds.Count > 0)
+                        {
+                            // it is a certainty we still have a peak to find
+                            maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
+                        }
+                        else
+                        {
+                            // if a new peak was identified, it has absorbed the pixels we found
+                            // we should continue with a lower search floor
+                            maybeMaximumPixelId = null;
+                            shouldContinueWithLowerSearchFloor = (noiseFloor < searchFloor);
+                        }
+                        break;
+                    }
+                case ReturnCode.exhaustedSuggestions:
+                    {
+                        maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
+                        break;
+                    }
+            }
+      
+        }
+    }
+
+    public List<PixelID> filterForAvailableIds(List<PixelID> pixelIds)
+    {
+        // return a list containing all the items in the
+        // input list which are in the unplacedPixelIds list
+        return pixelIds.Where(pixelId => unplacedPixelIds.Contains(pixelId)).ToList();
+    }
+}   
+
+
+
+
+

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -92,6 +92,8 @@ public class TwoDPeak
     DensityPlane referenceGrid;
     List<PixelID> foundIncreaseIds; // list of pixelIds at edge which increase relative to neighbor
     TwoDGridPartitionFinder partitionFinder; // will supply available neighbors
+    float peakValue;
+    float peakAgglomerationFraction;  // the value above which to ignore 'second peak'
 
     public TwoDPeak(TwoDGridPartitionFinder partitionFinder, DensityPlane grid, PixelID peakMaxPixelId)
     {
@@ -104,9 +106,11 @@ public class TwoDPeak
         this.topCandidates = new List<PixelSuggestion>();
         this.referenceGrid = grid;
         this.foundIncreaseIds = new List<PixelID>();
+        this.peakAgglomerationFraction = 0.8f; // hard code this value
 
-        float firstSuggestionScore = grid.valueAtPixel(peakMaxPixelId);
-        PixelSuggestion firstSuggestion = new PixelSuggestion(peakId, peakMaxPixelId, firstSuggestionScore);
+        this.peakValue = grid.valueAtPixel(peakMaxPixelId);
+        PixelSuggestion firstSuggestion = new PixelSuggestion(peakId, peakMaxPixelId, this.peakValue);
+
         nextCandidates.Add(firstSuggestion);
     }
 
@@ -143,7 +147,8 @@ public class TwoDPeak
             {
                 float neighborScore = referenceGrid.valueAtPixel(availableId);
 
-                if (neighborScore > suggestion.score)
+                // for now, hard code 
+                if ((neighborScore > suggestion.score) && (suggestion.score < this.peakValue * this.peakAgglomerationFraction))
                 {
                     // neighbor has higher score -- shouldn't add to current peak
                     // the currently 'accepted suggestion' is actually a pixel between peaks.

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -133,7 +133,6 @@ public class TwoDPeak
     // add adjacent pixels to list
     public void SuggestionAccepted(PixelSuggestion suggestion)
     {
-        Debug.WriteLine("SuggestionAccepted in peak " + this.peakId.DebugStr() + " : " + suggestion.DebugStr());
         removeFromCandidates(suggestion);
         bool isBorder = false;
         
@@ -153,7 +152,6 @@ public class TwoDPeak
                     // neighbor has higher score -- shouldn't add to current peak
                     // the currently 'accepted suggestion' is actually a pixel between peaks.
                     isBorder = true;
-                    Debug.WriteLine("Found increase at pixel " + availableId.DebugStr() + " neighborScore: " + neighborScore + " suggestionScore: " + suggestion.score);
                     foundIncreaseIds.Add(availableId);
                 }
                 else

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -1,0 +1,240 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System;
+using PcaExtensionMethods;
+
+
+// PixelSuggestion represents a pixel that could be added to a TwoDPeak as part of the PartitionFinder
+// peak partitioning algorithm
+public struct PixelSuggestion : IComparable<PixelSuggestion>
+{
+    public float score;
+    public PixelID pixelId;
+    public PeakID peakId;
+
+    public PixelSuggestion(PeakID peak, PixelID pixel, float score)
+    {
+        this.score = score;
+        this.pixelId = pixel;
+        this.peakId = peak;
+    }
+
+    public int CompareTo(PixelSuggestion other)
+    {
+        return other.score < score ? -1 : other.score > score ? 1 : 0;
+    }
+
+    public string DebugStr()
+    {
+        return "PixelID: " + pixelId.DebugStr() + ", score: " + score + ", peak: " + peakId.DebugStr();
+
+    }
+}
+
+
+// TwoDPeak represents a maximum in a DensityPlane grid and its surrounding pixels, as part of
+// the Partitioning algorithm implemented in TwoDGridPartitionFinder
+// Initially it is created with a single pixel location, and it grows to surrounding pixels
+// governed by the TwoDGridPartitionFinder.
+//
+// It maintains an ordered list of "pixels to add", and during the algorithm, repeated provides
+// to PartitionFinder the next 'best candidate' for adding to itself.  PartitionFinder evaluates all the 
+// candidates provided by all the peaks it knows about, and selects them.  When a candidate is selected
+// the SuggestionAccepted method is called, and new potential candidates are added to its list of "pixels to add"
+//
+// As an example, if the densities look like this:
+//
+//   50     70    50     40    30
+//   80    101   100     97    70
+//   70     99    98     80    60
+//   30     40    50     70    50   
+//
+// The peak would grow like this:
+//
+//  Cycle       values of ids in the Peak list   Values of Pixels in the candidates list 
+//  0           {}                               {101}
+//  1           {101}                            {100, 99, 80, 70}
+//  2           {101, 100}                       {99, 98, 97, 80, 70, 50}
+//  3           {101, 100, 99}                   {98, 97, 80, 70, 70, 50, 40}
+//  4           {101, 100, 99, 98}               {97, 80, 80, 70, 70, 50, 50, 40}
+//  5           {101, 100, 99, 98, 97}           {80, 80, 70, 70, 70, 50, 50, 40, 40}
+//  6           {101, 100, 99, 98, 97, 80, 80}   {70, 70, 70, 70, 60, 50, 50, 50, 40, 40}
+//
+// After step 5, both of the '80' pixels would be returned as part of the best candidates.
+//
+// A future logical addition:  right now, the algorithm won't handle the case very well where what should really 
+// be a single peak is actually two maxima very close together. Some logic should be added so that when a 
+// "increase" is found above a certain fraction of the peak maximum, it is not considered as evidence of a second peak.
+//
+// As an example, if the densities look like this:
+//
+//   50     70    50     40    30
+//   80    101   100     97    70
+//   70    100    98     99    80
+//   30     40    50     70    50    
+//
+// The algorthim will find two peaks but it should probably only find one
+// The logic could be that if a pixel at higher than some threshhold of
+// the peak maximum, say 75%, finds an increase, it shouldn't warn of an 'increase found'
+// result, but just accumulate that pixel as well
+// in the example above, the peak would start at 101, then grow to the two 100 pixels.
+// the next candidate offered/accepted would be the 98 pixel.  At that point, the 99
+// pixel would be considered for adding to the candudates list, but as it is an increase from 
+// 98, algorithm would flag it as the case where a second peak must exist.
+public class TwoDPeak
+{
+    public PeakID peakId;
+    PixelID peakMaxPixelId; // this is also the id for this object in container's dictionary
+    List<PixelID> borderPixelIds;
+    List<PixelID> inPeakPixelIds;
+    List<PixelSuggestion> nextCandidates;
+    List<PixelSuggestion> topCandidates; // this list is recycled as the return vehicle for getting next suggestions
+    DensityPlane referenceGrid;
+    List<PixelID> foundIncreaseIds; // list of pixelIds at edge which increase relative to neighbor
+    TwoDGridPartitionFinder partitionFinder; // will supply available neighbors
+
+    public TwoDPeak(TwoDGridPartitionFinder partitionFinder, DensityPlane grid, PixelID peakMaxPixelId)
+    {
+        this.partitionFinder = partitionFinder;
+        this.peakMaxPixelId = peakMaxPixelId;
+        this.peakId = new PeakID(peakMaxPixelId);
+        this.inPeakPixelIds = new List<PixelID>();
+        this.borderPixelIds = new List<PixelID>();
+        this.nextCandidates = new List<PixelSuggestion>();
+        this.topCandidates = new List<PixelSuggestion>();
+        this.referenceGrid = grid;
+        this.foundIncreaseIds = new List<PixelID>();
+
+        float firstSuggestionScore = grid.valueAtPixel(peakMaxPixelId);
+        PixelSuggestion firstSuggestion = new PixelSuggestion(peakId, peakMaxPixelId, firstSuggestionScore);
+        nextCandidates.Add(firstSuggestion);
+    }
+
+    public List<PixelID> PixelList()
+    {
+        return inPeakPixelIds;
+    }
+
+    public bool HasFoundIncrease()
+    {
+        return foundIncreaseIds.Count > 0;
+    }
+    // if suggestion accepted, remove from list and 
+    // add adjacent pixels to list
+    public void removeFromCandidates(PixelSuggestion suggestion)
+    {
+        nextCandidates.Remove(suggestion);
+    }
+    // if suggestion accepted, remove from list and 
+    // add adjacent pixels to list
+    public void SuggestionAccepted(PixelSuggestion suggestion)
+    {
+        Debug.WriteLine("SuggestionAccepted in peak " + this.peakId.DebugStr() + " : " + suggestion.DebugStr());
+        removeFromCandidates(suggestion);
+        bool isBorder = false;
+        
+        List<PixelID> newPossibilities = referenceGrid.PixelIdsNeighboring(suggestion.pixelId);
+        List<PixelID> availableIds = partitionFinder.filterForAvailableIds(newPossibilities);
+        foreach(PixelID availableId in availableIds)
+        {
+            // this might already be in our list of candidates -- if it is, skip
+
+            if (!IsCandidate(availableId))
+            {
+                float neighborScore = referenceGrid.valueAtPixel(availableId);
+
+                if (neighborScore > suggestion.score)
+                {
+                    // neighbor has higher score -- shouldn't add to current peak
+                    // the currently 'accepted suggestion' is actually a pixel between peaks.
+                    isBorder = true;
+                    Debug.WriteLine("Found increase at pixel " + availableId.DebugStr() + " neighborScore: " + neighborScore + " suggestionScore: " + suggestion.score);
+                    foundIncreaseIds.Add(availableId);
+                }
+                else
+                {
+                    PixelSuggestion newSuggestion = new PixelSuggestion(peakId, availableId, neighborScore);
+                    this.InsertCandidate(newSuggestion);
+                }
+            }
+        }
+        if (isBorder)
+        {
+            borderPixelIds.Add(suggestion.pixelId);
+        }
+        else
+        {
+            inPeakPixelIds.Add(suggestion.pixelId);
+        }
+    }
+
+    public bool IsCandidate(PixelID pixelId)
+    {
+        foreach ( PixelSuggestion candidate in  nextCandidates)
+        {
+            if (candidate.pixelId.pixelId == pixelId.pixelId)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public List<PixelID> ClearFoundIncreases()
+    {
+        List<PixelID> returnList =  foundIncreaseIds;
+        foundIncreaseIds = new List<PixelID>();
+        return returnList;
+    }
+
+
+    // this peak maintains a list of the candidate neighbor pixels 
+    // which could be added to the peak during the accumulation
+    // the 
+    public void InsertCandidate(PixelSuggestion candidate)
+    {
+        nextCandidates.AddSorted(candidate);
+    }
+    // if suggestion rejected, remove from list
+    public void SuggestionRejected(PixelSuggestion suggestion)
+    {
+        removeFromCandidates(suggestion);
+    }
+
+    public List<PixelSuggestion> NextSuggestions()
+    {
+        topCandidates.Clear();
+        if (nextCandidates.Count > 0)
+        {
+            var topCandidate = nextCandidates[0];
+            topCandidates.Add(topCandidate);
+            float bestScore = topCandidate.score;
+            bool keepGoing = true;
+            int nextIndex = 1;
+            while (keepGoing)          
+            {
+                if (nextIndex < nextCandidates.Count)
+                {
+                    topCandidate = nextCandidates[nextIndex];
+                    if (topCandidate.score < bestScore)
+                    {
+                        keepGoing = false;
+                    }
+                    else
+                    {
+                        topCandidates.Add(topCandidate);
+                        nextIndex += 1;
+                    }  
+                }
+                else { keepGoing = false; }
+                
+            }
+        }
+        return topCandidates;
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
This is work in progress, as some of the parameters of the calculation are hard coded, and there is still work to do in voxel assignment.  However, this is ready for a provisional PR so as to generate a NuGet package.

This version of the algorithm generates three 2D projections from the first three PCA dimensions, using the pairs

    0-1   0-2   1-2

And identifies peaks in those 2D projections, assigning a code to each voxel based on which peak it is a part of in each grid.

The 0-1 projection (a 2D projection of the first and second PCA dimensions ) is designated grid A, and if a voxel is part of the first peak identified in gridA, it gets "A1" as part of its PCA code.  If it was not part of an identified peak, it gets "A0".

As there are three grids, each voxel gets a three part designation, such as "A1 B2 C1"
Each collection of voxels with designations not having a 0 -- i.e. voxels which land inside peaks in all three grids -- form the basis of 'PCA phases' in the sample.  Subsequently, neighboring voxels that include a "0" in their PCA codes can be added to regions of the PCA phases if their non-zero designations match.  Vocels which neighbor multiple matching PCA phases are designated "interface voxels"

The four most populated buckets are displayed in the components pane as "Component 1", "Component 2", "Component 3", "Component 4",   In the display, "Component 0" shows unassigned voxels, and "Component 5" shows "Interface" Voxels.

The "Grids" pane shows the 2D projections (One must click the "Advance to Next Grid" button to populate the graph".

Subsequent PR will add some hard coded algorithm values to the Properties pane so that users can adjust these values.