### PR TITLE
Ohellman/pca phase

### DIFF
--- a/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
@@ -11,8 +11,6 @@ public sealed class ComponentsResults
 
     public int[] VoxelIndices { get; }
 
-    public PhaseIdResults PhaseIDResults { get; set; }
-
     public List<ComponentResults> Components { get; }
 
     public ComponentsResults(IGrid3DData grid3DData, int[] voxelIndices, List<ComponentResults> components)
@@ -22,7 +20,6 @@ public sealed class ComponentsResults
         Components = components;
 
         List<VoxelID> emptyList = new List<VoxelID>();
-        PhaseIDResults = new PhaseIdResults(emptyList);
     }
 
 }

--- a/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
@@ -13,12 +13,3 @@ public sealed class TwoDPeakProjection
     }
 }
 
-public sealed class TwoDPeakProjections
-{
-    public List<TwoDPeakProjection> projections;
-
-    public TwoDPeakProjections(List<TwoDPeakProjection> twoDPeakProjections)
-    {
-        this.projections = twoDPeakProjections;
-    }
-}

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -9,14 +9,30 @@ namespace Cameca.CustomAnalysis.Pca;
 
 public delegate float[] GetScoresDelegate(int voxelIndex);
 
+public struct PcaPhaseIdentificationProperties
+{
+    public float noiseFloorFraction;
+    public float peakSummitAllowance;
+    public int numDimsForPCAPhaseId;
+
+    public PcaPhaseIdentificationProperties(float noiseFloor, float peakSummitAllowance, int numDimsForPCAPhaseId)
+    {
+        this.noiseFloorFraction = noiseFloor;
+        this.peakSummitAllowance = peakSummitAllowance;
+        this.numDimsForPCAPhaseId = numDimsForPCAPhaseId;
+    }
+}
+
 public class PcaScoresGridProducer: IScoresProvider {
 
     ComponentsResults compResults;
+    PcaPhaseIdentificationProperties properties;
     int nComponents;
 
-    public PcaScoresGridProducer(ComponentsResults results)
+    public PcaScoresGridProducer(ComponentsResults results, PcaPhaseIdentificationProperties props)
     {
         compResults = results;
+        properties = props;
         nComponents = compResults.Components.Count;
     }
 
@@ -43,6 +59,7 @@ public class PcaScoresGridProducer: IScoresProvider {
         return new PcaScoresGrid(this, compResults.VoxelIndices.Count(), nComponents, gridDimensions);
     }
 }
+
 
 internal static class PcaCalculator
 {
@@ -100,13 +117,13 @@ internal static class PcaCalculator
     }
 
     // manipulate the results of PCA to identify phases per voxel
-    public static PhaseIdResults GetPhases(IIonData ionData, ComponentsResults compResults)
+    public static PhaseIdResults GetPhases(IIonData ionData, ComponentsResults compResults, PcaPhaseIdentificationProperties properties)
     {
         // make a PcaGrid, then call grid.GetPhases
-        PcaScoresGridProducer producer = new PcaScoresGridProducer(compResults);
+        PcaScoresGridProducer producer = new PcaScoresGridProducer(compResults, properties);
 
         PcaScoresGrid scoresGrid = producer.ScoresGrid();
-        return scoresGrid.GetPhasesStrategyE();
+        return scoresGrid.GetPhasesStrategyE(properties);
     }
 
     public static NoiseEigenvalueResults GetNoiseEigenvalues(float[] evals, int gaps, int significance, bool refine)

--- a/Cameca.CustomAnalysis.Pca/PcaProperties.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaProperties.cs
@@ -56,6 +56,18 @@ public partial class PcaProperties : ObservableObject
     [ObservableProperty]
     private bool invert = false;
 
+    [ObservableProperty]
+    [field: Display(Name = "Noise Floor")]
+    private float noiseFloorFraction = 0.1f;
+
+    [ObservableProperty]
+    [field: Display(Name = "Peak Summit Allowance")]
+    private float peakSummitAllowance = 0.8f;
+
+    [ObservableProperty]
+    [field: Display(Name = "PCA Phase Id Dimensions")]
+    private int numDimsForPCAPhaseId = 3;
+
     [Display(AutoGenerateField = false)]
     public SerializableColorMap? ColorMap { get; set; }
 }

--- a/Cameca.CustomAnalysis.Pca/PcaProperties.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaProperties.cs
@@ -68,8 +68,19 @@ public partial class PcaProperties : ObservableObject
     [field: Display(Name = "PCA Phase Id Dimensions")]
     private int numDimsForPCAPhaseId = 3;
 
+    [ObservableProperty]
+    [field: Display(Name = "PCA Phase Index")]
+    private int pcaPhaseIndex = 0;
+
+    [ObservableProperty]
+    [field: Display(Name = "Use PCA Phase for Detatched ROI")]
+    private bool usePCAPhaseForDetatchedROI = true;
+
     [Display(AutoGenerateField = false)]
-    public SerializableColorMap? ColorMap { get; set; }
+    public SerializableColorMap? PcaColorMap { get; set; }
+
+    [Display(AutoGenerateField = false)]
+    public SerializableColorMap? ComponentsColorMap { get; set; }
 }
 
 public class SerializableColorMap

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -136,6 +136,32 @@
                 </utils:ButtonOverlayControl>
             </TabItem>
 
+            <TabItem Header="Loading">
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
+                                ButtonContent="Update"
+                                OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <lvc:CartesianChart Series="{Binding LoadingsSeries}"
+                                        DisableAnimations="True"
+                                        LegendLocation="None">
+                        <lvc:CartesianChart.Resources>
+                            <Style TargetType="lvc:DefaultTooltip">
+                                <Setter Property="ShowSeries" Value="False" />
+                            </Style>
+                        </lvc:CartesianChart.Resources>
+                        <lvc:CartesianChart.AxisX>
+                            <lvc:Axis Labels="{Binding LoadingsLabels}" FontSize="18">
+                                <lvc:Axis.Separator>
+                                    <lvc:Separator Step="1" />
+                                </lvc:Axis.Separator>
+                            </lvc:Axis>
+                        </lvc:CartesianChart.AxisX>
+                        <lvc:CartesianChart.AxisY>
+                            <lvc:Axis Title="Loadings" FontSize="18" LabelFormatter="{Binding AxisYLabelFormatter, Mode=OneTime}" />
+                        </lvc:CartesianChart.AxisY>
+                    </lvc:CartesianChart>
+                </utils:ButtonOverlayControl>
+            </TabItem>
+            
             <TabItem Header="Scores">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
                             ButtonContent="Update"

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -33,7 +33,7 @@
                     </Grid>
                 </utils:ButtonOverlayControl>
             </TabItem>
-
+            
             <TabItem Header="Components">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
                                 ButtonContent="Update"
@@ -52,6 +52,7 @@
                         <local:ComponentsTileView Grid.Column="0"
                                                   Grid.Row="0"
                                                   Grid.RowSpan="3"
+                                                  IsPcaPhases="false"
                                                   ItemsSource="{Binding ComponentRenderData}" />
                         <Grid Grid.Column="1"
                               Grid.Row="0">
@@ -72,12 +73,12 @@
                                 </TextBox.Text>
                             </TextBox>
                         </Grid>
-                        
+
                         <controls:ColorMapEditor Grid.Column="1"
                                                  Grid.Row="1"
                                                  ColorMap="{Binding ColorMap}"
                                                  ValueLabel="Score" />
-                        
+
                         <Grid Grid.Column="1"
                               Grid.Row="2">
                             <Grid.ColumnDefinitions>
@@ -101,6 +102,31 @@
                 </utils:ButtonOverlayControl>
             </TabItem>
 
+            <TabItem Header="PCA Phases">
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
+                                ButtonContent="Update"
+                                OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+
+                        <local:ComponentsTileView Grid.Column="0"
+                                                  Grid.Row="0"
+                                                  Grid.RowSpan="3"
+                                                  IsPcaPhases="true" 
+                                                  ItemsSource="{Binding PcaPhasesRenderData}" />
+
+                    </Grid>
+                </utils:ButtonOverlayControl>
+            </TabItem>
+
             <TabItem Header="Grids">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
                                ButtonContent="Update"
@@ -109,7 +135,7 @@
 
                 </utils:ButtonOverlayControl>
             </TabItem>
-            
+
             <TabItem Header="Loading">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
                                 ButtonContent="Update"

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -76,7 +76,7 @@
 
                         <controls:ColorMapEditor Grid.Column="1"
                                                  Grid.Row="1"
-                                                 ColorMap="{Binding ColorMap}"
+                                                 ColorMap="{Binding ComponentsColorMap}"
                                                  ValueLabel="Score" />
 
                         <Grid Grid.Column="1"
@@ -103,9 +103,9 @@
             </TabItem>
 
             <TabItem Header="PCA Phases">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
                                 ButtonContent="Update"
-                                OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                OverlayVisibility="{Binding UpdatePCAPhasesCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -128,37 +128,11 @@
             </TabItem>
 
             <TabItem Header="Grids">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
                                ButtonContent="Update"
-                               OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                               OverlayVisibility="{Binding UpdatePCAPhasesCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}" />
 
-                </utils:ButtonOverlayControl>
-            </TabItem>
-
-            <TabItem Header="Loading">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
-                                ButtonContent="Update"
-                                OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <lvc:CartesianChart Series="{Binding LoadingsSeries}"
-                                        DisableAnimations="True"
-                                        LegendLocation="None">
-                        <lvc:CartesianChart.Resources>
-                            <Style TargetType="lvc:DefaultTooltip">
-                                <Setter Property="ShowSeries" Value="False" />
-                            </Style>
-                        </lvc:CartesianChart.Resources>
-                        <lvc:CartesianChart.AxisX>
-                            <lvc:Axis Labels="{Binding LoadingsLabels}" FontSize="18">
-                                <lvc:Axis.Separator>
-                                    <lvc:Separator Step="1" />
-                                </lvc:Axis.Separator>
-                            </lvc:Axis>
-                        </lvc:CartesianChart.AxisX>
-                        <lvc:CartesianChart.AxisY>
-                            <lvc:Axis Title="Loadings" FontSize="18" LabelFormatter="{Binding AxisYLabelFormatter, Mode=OneTime}" />
-                        </lvc:CartesianChart.AxisY>
-                    </lvc:CartesianChart>
                 </utils:ButtonOverlayControl>
             </TabItem>
 

--- a/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
+++ b/Cameca.CustomAnalysis.Pca/PhaseIDResults.cs
@@ -10,45 +10,58 @@ using Cameca.CustomAnalysis.Pca;
 // or 0 if no phase is identified
 public class PhaseIdResults
 {
-    Dictionary<VoxelID, int> identifiedPhase;
-    Dictionary<string, TwoDPeakProjection> twoDPeakProjections;
+    public Dictionary<VoxelID, int> IdentifiedPhase;
+    public Dictionary<string, TwoDPeakProjection> TwoDPeakProjections;
+    public Dictionary<string, int> PhaseIndexMap; // the values in identifiedPhase dictionary should correspond to the PCA codes in this list
+                                           // there should be an entry "0" with the key "Unassigned Voxels"
+                                           // there should be an entry N with the key "Interface Voxels" -- the index with the greatest value
+                                           // So, the number of PCA Phases should be phaseIndexMap.Count - 2
 
     public PhaseIdResults(List<VoxelID> voxelIds)
     {
-        identifiedPhase = new Dictionary<VoxelID, int>();
+        this.IdentifiedPhase = new Dictionary<VoxelID, int>();
         // not-yet-identified voxels are identified as 0
         for (int i = 0; i < voxelIds.Count; ++i)
         {
-            identifiedPhase[voxelIds[i]] = 0;
+            this.IdentifiedPhase[voxelIds[i]] = 0;
         }
-        twoDPeakProjections = new Dictionary<string, TwoDPeakProjection>();
+        this.TwoDPeakProjections = new Dictionary<string, TwoDPeakProjection>();
+        this.PhaseIndexMap = new Dictionary<string, int>();
+    }
+
+    public Dictionary<int, string> PhaseNamesMap() 
+    {
+        Dictionary<int, string> namesMap = new Dictionary<int, string>();
+        // just reverse Keys and Values of phaseIndexMap
+        foreach (KeyValuePair<string, int> kvp in PhaseIndexMap)
+        {
+            namesMap[kvp.Value] = kvp.Key;
+        }
+
+        return namesMap;
     }
 
     public void SetTwoDPeakProjectionFor(string key, TwoDPeakProjection projection)
     {
-        twoDPeakProjections[key] = projection;
-    }
-    public Dictionary<string, TwoDPeakProjection> TwoDPeakProjections()
-    {
-        return twoDPeakProjections;
+        TwoDPeakProjections[key] = projection;
     }
 
     public void IdentifyVoxelAs(VoxelID voxelId, int phase)
     {
-        identifiedPhase[voxelId] = phase;
+        IdentifiedPhase[voxelId] = phase;
     }
     public void IdentifyVoxelsAs(List<VoxelID> voxelIds, int phase)
     {
         foreach (VoxelID voxelId in voxelIds) {
-            identifiedPhase[voxelId] = phase;
+            IdentifiedPhase[voxelId] = phase;
         }
     }
 
     public int? PhaseForVoxel(VoxelID voxelId)
     {
-        if (identifiedPhase.ContainsKey(voxelId))
+        if (IdentifiedPhase.ContainsKey(voxelId))
         {
-            return identifiedPhase[voxelId];
+            return IdentifiedPhase[voxelId];
         }
         return null;
     }
@@ -56,9 +69,9 @@ public class PhaseIdResults
     public int? PhaseForVoxelIntValue(int voxelIndex)
     {
         VoxelID voxelId = new VoxelID(voxelIndex);
-        if (identifiedPhase.ContainsKey(voxelId))
+        if (IdentifiedPhase.ContainsKey(voxelId))
         {
-            return identifiedPhase[voxelId];
+            return IdentifiedPhase[voxelId];
         }
         return null;
     }
@@ -66,13 +79,18 @@ public class PhaseIdResults
     public List<VoxelID> UnidentifiedVoxels()
     {
         var unidentifiedIndices = new List<VoxelID>();
-        foreach ( KeyValuePair<VoxelID, int> voxel in identifiedPhase )
+        foreach ( KeyValuePair<VoxelID, int> voxel in IdentifiedPhase )
         {
             if (voxel.Value == 0) {
                 unidentifiedIndices.Add(voxel.Key);
             }
         }
         return unidentifiedIndices;
+    }
+
+    public void SetPhaseIndexMap(Dictionary<string, int> indexMap)
+    {
+        PhaseIndexMap = indexMap;
     }
 }
     

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -21,6 +21,7 @@ using CommunityToolkit.HighPerformance;
 using System.Windows.Markup;
 using System.Runtime.Intrinsics.Arm;
 using Cameca.Extensions.Controls;
+using Cameca.CustomAnalysis.Pca;
 
 namespace Cameca.CustomAnalysis.Pca;
 
@@ -42,7 +43,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private ICollection<IRenderData> pcaPhasesRenderData = Array.Empty<IRenderData>();
 
     [ObservableProperty]
-    private IColorMap? colorMap = null;
+    private IColorMap? pcaColorMap = null;
+
+    [ObservableProperty]
+    private IColorMap? componentsColorMap = null;
 
     [ObservableProperty]
     private ICollection<IRenderData> selectedGridRenderData = Array.Empty<IRenderData>();
@@ -62,15 +66,14 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private ComponentsResults? componentsResults;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateComponentsCanExecute))]
-    [NotifyCanExecuteChangedFor(nameof(UpdateComponentsCommand))]
-    private TwoDPeakProjections? twoDPeakProjections;
+    [NotifyPropertyChangedFor(nameof(UpdatePCAPhasesCanExecute))]
+    [NotifyCanExecuteChangedFor(nameof(UpdatePCAPhasesCommand))]
+    private PhaseIdResults? pcaPhaseIDResults;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
     private SeriesCollection loadingsSeries = new();
-
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
@@ -84,6 +87,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     public ICollection<IRenderData> scoresHistogramData = Array.Empty<IRenderData>();
 
     public bool UpdateComponentsCanExecute => ComponentsResults is null;
+    public bool UpdatePCAPhasesCanExecute => PcaPhaseIDResults is null;
 
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
 
@@ -105,9 +109,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
     protected override byte[]? GetSaveContent()
     {
-        if (ColorMap is not null)
+        if (PcaColorMap is not null)
         {
-            Properties.ColorMap = SerializeColorMap(ColorMap);
+            Properties.PcaColorMap = SerializeColorMap(PcaColorMap);
+        }
+        if (ComponentsColorMap is not null)
+        {
+            Properties.ComponentsColorMap = SerializeColorMap(ComponentsColorMap);
         }
         return base.GetSaveContent();
     }
@@ -191,14 +199,46 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         var compResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
 
-        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
-        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults, pcaPhaseIdProperties);
-
-        compResults.PhaseIDResults = phaseIDResults;
-
         ComponentsResults = compResults;
-        
+
         UpdateOptionsBounds();
+
+        // Ensure that the selected component falls in the valid range of number of components
+        if (Properties.PcaPhaseIndex < 0)
+        {
+            Properties.ComponentIndex = 0;
+        }
+        else if (Properties.ComponentIndex > Properties.Components)
+        {
+            Properties.ComponentIndex = Properties.Components;
+        }
+
+        await UpdateSelectedComponent(cancellationToken);
+    }
+
+    // PCA Phases can be updated independently of the Components if the number of grids to use changes
+    // or if any of the properties to use in the calculation change
+    [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
+    public async Task UpdatePCAPhases(CancellationToken cancellationToken)
+    {
+        DataStateIsError = false;
+        if (await Resources.GetIonData(cancellationToken: cancellationToken) is not { } ionData)
+        {
+            DataStateIsError = true;
+            return;
+        }
+
+        var gridNode = Resources.GetGrid();
+        if (gridNode is null || await gridNode.GetDataAsync<IGrid3DData>(cancellationToken: cancellationToken) is not { } gridData)
+        {
+            DataStateIsError = true;
+            return;
+        }
+
+        var compResults = ComponentsResults;
+
+        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
+        PcaPhaseIDResults = PcaCalculator.GetPhases(ionData, compResults, pcaPhaseIdProperties);
 
         // Ensure that the selected component falls in the valid range of number of components
         if (Properties.ComponentIndex < 0)
@@ -342,15 +382,76 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     // Updates the components 3D plots when the component data (derived from selected number of components) changes
+    partial void OnPcaPhaseIDResultsChanged(PhaseIdResults? value)
+    {
+        if (PcaPhaseIDResults is { IdentifiedPhase: Dictionary<VoxelID, int> identifiedPhase,
+            TwoDPeakProjections: Dictionary<string, TwoDPeakProjection> twoDPeakProjections,
+            PhaseIndexMap: Dictionary<string, int> phaseIndexMap } )
+     
+         {   
+             PcaPhasesRenderData = Array.Empty<IRenderData>();
+
+             Dictionary<int, string> phaseNamesMap = PcaPhaseIDResults.PhaseNamesMap();
+             int numPhases = phaseNamesMap.Count; // need to figure out how to not hard code
+             // int selectedIndex = Properties.ComponentIndex;
+
+            var newPhasesData = new IRenderData[numPhases];
+            IValuePointsRenderData? rootValuePoints2 = null;
+            for (int compIndex = 0; compIndex < numPhases; compIndex++)
+            {
+                var phaseIdScores = GetPhaseIdScoresForVoxelIndices(PcaPhaseIDResults, compIndex, ComponentsResults.VoxelIndices);
+
+                // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
+                // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
+                var positionsWithValues = PositionScores.GetScoredPositions(ComponentsResults.Grid3DData, ComponentsResults.VoxelIndices, phaseIdScores);
+
+                var valuePoints = Resources.ChartObjects.CreateValuePoints();
+        
+                valuePoints.Name = phaseNamesMap[compIndex];
+                valuePoints.PositionsWithValues = positionsWithValues;
+                if (rootValuePoints2 is null)
+                {
+                    rootValuePoints2 = valuePoints;
+                    rootValuePoints2.ColorMap = DeserializeColorMap(Properties.PcaColorMap);
+                }
+                else
+                {
+                    valuePoints.ColorMap = rootValuePoints2.ColorMap;
+                }
+
+                newPhasesData[compIndex] = valuePoints;
+            }
+
+            if (rootValuePoints2?.ColorMap is not null)
+            {
+                PcaColorMap = rootValuePoints2.ColorMap;
+                PcaColorMap.BottomValue = 0.0f;
+                PcaColorMap.TopValue = 1.0f;
+            }
+
+            PcaPhasesRenderData = newPhasesData;
+            int gridCount = twoDPeakProjections.Count;
+            var newGridProjectionsData = new List<IRenderData>();
+            foreach (KeyValuePair<string, TwoDPeakProjection> kvp in twoDPeakProjections)
+            {
+                var histogram = Resources.ChartObjects.CreateHistogram2D();
+                histogram.Name = kvp.Key;
+                histogram.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
+                FillRenderDataWithGridData(histogram, kvp.Value);
+                newGridProjectionsData.Add(histogram);
+            }
+            SelectedGridRenderData = newGridProjectionsData;
+        }
+    }
+
+    // Updates the components 3D plots when the component data (derived from selected number of components) changes
     partial void OnComponentsResultsChanged(ComponentsResults? value)
     {
         ComponentRenderData = Array.Empty<IRenderData>();
-        PcaPhasesRenderData = Array.Empty<IRenderData>();
         SelectedGridRenderData = Array.Empty<IRenderData>();
 
         if (ComponentsResults is not { Grid3DData: { } gridData,
             Components: { } components,
-            PhaseIDResults: { } phaseIdResults,
             VoxelIndices: { } voxelIndices }
          || Resources.GetValidIonData() is not { } ionData)
         {
@@ -375,7 +476,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             if (rootValuePoints is null)
             {
                 rootValuePoints = valuePoints;
-                rootValuePoints.ColorMap = DeserializeColorMap(Properties.ColorMap);
+                rootValuePoints.ColorMap = DeserializeColorMap(Properties.ComponentsColorMap);
             }
             else
             {
@@ -387,78 +488,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         if (rootValuePoints?.ColorMap is not null)
         {
-            ColorMap = rootValuePoints.ColorMap;
+            ComponentsColorMap = rootValuePoints.ColorMap;
             var range = GetRange(components.Select(x => x.Scores));
-            ColorMap.BottomValue = range.Low;
-            ColorMap.TopValue = range.High;
+            ComponentsColorMap.BottomValue = range.Low;
+            ComponentsColorMap.TopValue = range.High;
         }
 
         ComponentRenderData = newComponentsData;
-
-        //Almost the same as ComponentRenderData, but PcaRenderData
-        int numPhases = 7; // need to figure out how to not hard code
-        // int selectedIndex = Properties.ComponentIndex;
-
-        var newPhasesData = new IRenderData[numPhases];
-        IValuePointsRenderData? rootValuePoints2 = null;
-        for (int compIndex = 0; compIndex < numPhases; compIndex++)
-        {
-
-            var phaseIdScores = GetPhaseIdScoresForVoxelIndices(phaseIdResults, compIndex, voxelIndices);
-
-            // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
-            // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
-            var positionsWithValues = PositionScores.GetScoredPositions(gridData, voxelIndices, phaseIdScores);
-
-            var valuePoints = Resources.ChartObjects.CreateValuePoints();
-            if (compIndex == 0)
-            {
-                valuePoints.Name = $"Unassigned Voxels";
-            }
-            else if (compIndex == (numPhases - 1)) 
-            {
-                valuePoints.Name = $"Interface Voxels";
-            }
-            else
-            {
-                valuePoints.Name = $"Pca Phase {compIndex}";
-            }
-                
-            valuePoints.PositionsWithValues = positionsWithValues;
-            if (rootValuePoints2 is null)
-            {
-                rootValuePoints2 = valuePoints;
-                rootValuePoints2.ColorMap = DeserializeColorMap(Properties.ColorMap);
-            }
-            else
-            {
-                valuePoints.ColorMap = rootValuePoints2.ColorMap;
-            }
-
-            newPhasesData[compIndex] = valuePoints;
-        }
-
-        if (rootValuePoints?.ColorMap is not null)
-        {
-            ColorMap = rootValuePoints.ColorMap;
-            ColorMap.BottomValue = 0.0f;
-            ColorMap.TopValue = 1.0f;
-        }
-
-        PcaPhasesRenderData = newPhasesData;
-
-        var peakProjections = phaseIdResults.TwoDPeakProjections();
-        int gridCount = peakProjections.Count;
-        var newGridProjectionsData = new List<IRenderData>();
-        foreach (KeyValuePair<string, TwoDPeakProjection> kvp in peakProjections)
-        {
-            var histogram = Resources.ChartObjects.CreateHistogram2D();
-            histogram.Name = kvp.Key;
-            histogram.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
-            FillRenderDataWithGridData(histogram, kvp.Value);
-            newGridProjectionsData.Add(histogram);
-        }
-        SelectedGridRenderData = newGridProjectionsData;
     }
 
     private static (float Low, float High) GetRange(IEnumerable<float[]> scores)
@@ -571,62 +607,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
   
     protected override async IAsyncEnumerable<ReadOnlyMemory<ulong>> GetIndicesDelegateAsync(IIonData ionData, IProgress<double>? progress, [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        DataStateIsError = false;
-        if (ComponentsResults is null)
-        {
-            await UpdateComponents(cancellationToken);
-        }
 
-        // Extract necessary data out of ComponentsResults using some pattern matching for null checks and variable assignment
-        if (ComponentsResults is not { Grid3DData: { } gridData, VoxelIndices: { } nonEmptyVoxels }
-            || ComponentsResults.Components[Properties.ComponentIndex] is not { Scores: { } scores })
-        {
-            DataStateIsError = true;
-            yield break;
-        }
-        var phaseIds = ComponentsResults.PhaseIDResults;
-        int componentOfInterest = Properties.ComponentIndex;
-        var minVector = gridData.GetMinVector();
-        var voxelSize = gridData.GetVoxelSizeDimensions();
-        int xBinStride = gridData.NumVoxels[0];
-        int yBinStride = gridData.NumVoxels[1];
-        var binner = new PositionToVoxels(minVector, voxelSize, xBinStride, yBinStride);
-
-        // Create a map of voxel index to the associated score
-        var scoredVoxels = nonEmptyVoxels
-            .Zip(scores)
-            .ToDictionary(x => x.First, x => x.Second);
-
-        // Build buffers of filtered indices to return
-        // Iterating through each point (to determine inclusion) is a bit of a complex chunked iterator code to support >Int32.MaxValue number of ions in a data set
-        ulong index = 0ul;
-        float threshold = Properties.Isovalue;
-        foreach (var chunk in ionData.CreateSectionDataEnumerable(IonDataSectionName.Position))
-        {
-            int bufferIndex = 0;
-            using var buffer = MemoryOwner<ulong>.Allocate(chunk.Length);
-            var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
-            for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
-            {
-                int bin = binner.ToVoxel(positions.Span[chunkIndex]);
-
-                // Properties.ComponentIndex is the selectedComponent
-                if (phaseIds.PhaseForVoxelIntValue(bin) == componentOfInterest) 
-                // if (scoredVoxels.TryGetValue(bin, out float score) && score >= threshold)
-                {
-                    buffer.Span[bufferIndex++] = index;
-                }
-                index += 1ul;
-            }
-            yield return buffer.Slice(0, bufferIndex).Memory;
-        }
-
-        DataStateIsValid = true;
-    }
-
-    /*
-    protected override async IAsyncEnumerable<ReadOnlyMemory<ulong>> GetIndicesDelegateAsync(IIonData ionData, IProgress<double>? progress, [EnumeratorCancellation] CancellationToken cancellationToken)
-    {
         DataStateIsError = false;
         if (ComponentsResults is null)
         {
@@ -645,37 +626,68 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         var voxelSize = gridData.GetVoxelSizeDimensions();
         int xBinStride = gridData.NumVoxels[0];
         int yBinStride = gridData.NumVoxels[1];
+
         var binner = new PositionToVoxels(minVector, voxelSize, xBinStride, yBinStride);
 
-        // Create a map of voxel index to the associated score
-        var scoredVoxels = nonEmptyVoxels
-            .Zip(scores)
-            .ToDictionary(x => x.First, x => x.Second);
-
-        // Build buffers of filtered indices to return
-        // Iterating through each point (to determine inclusion) is a bit of a complex chunked iterator code to support >Int32.MaxValue number of ions in a data set
-        ulong index = 0ul;
-        float threshold = Properties.Isovalue;
-        foreach (var chunk in ionData.CreateSectionDataEnumerable(IonDataSectionName.Position))
+        if (Properties.UsePCAPhaseForDetatchedROI)
         {
-            int bufferIndex = 0;
-            using var buffer = MemoryOwner<ulong>.Allocate(chunk.Length);
-            var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
-            for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
+            var phaseIds = PcaPhaseIDResults;
+            int pcaPhaseOfInterest = Properties.PcaPhaseIndex;
+
+            // Build buffers of filtered indices to return
+            // Iterating through each point (to determine inclusion) is a bit of a complex chunked iterator code to support >Int32.MaxValue number of ions in a data set
+            ulong index = 0ul;
+            foreach (var chunk in ionData.CreateSectionDataEnumerable(IonDataSectionName.Position))
             {
-                var bin = binner.ToVoxel(positions.Span[chunkIndex]);
-                if (scoredVoxels.TryGetValue(bin, out float score) && score >= threshold)
+                int bufferIndex = 0;
+                using var buffer = MemoryOwner<ulong>.Allocate(chunk.Length);
+                var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
+                for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
                 {
-                    buffer.Span[bufferIndex++] = index;
+                    int bin = binner.ToVoxel(positions.Span[chunkIndex]);
+
+                    // Properties.ComponentIndex is the selectedComponent
+                    if (phaseIds.PhaseForVoxelIntValue(bin) == pcaPhaseOfInterest)
+                    {
+                        buffer.Span[bufferIndex++] = index;
+                    }
+                    index += 1ul;
                 }
-                index += 1ul;
+                yield return buffer.Slice(0, bufferIndex).Memory;
             }
-            yield return buffer.Slice(0, bufferIndex).Memory;
+        }
+        else 
+        {
+
+            // Create a map of voxel index to the associated score
+            var scoredVoxels = nonEmptyVoxels
+                .Zip(scores)
+                .ToDictionary(x => x.First, x => x.Second);
+
+            // Build buffers of filtered indices to return
+            // Iterating through each point (to determine inclusion) is a bit of a complex chunked iterator code to support >Int32.MaxValue number of ions in a data set
+            ulong index = 0ul;
+            float threshold = Properties.Isovalue;
+            foreach (var chunk in ionData.CreateSectionDataEnumerable(IonDataSectionName.Position))
+            {
+                int bufferIndex = 0;
+                using var buffer = MemoryOwner<ulong>.Allocate(chunk.Length);
+                var positions = chunk.ReadSectionData<Vector3>(IonDataSectionName.Position);
+                for (int chunkIndex = 0; chunkIndex < chunk.Length; chunkIndex++)
+                {
+                    var bin = binner.ToVoxel(positions.Span[chunkIndex]);
+                    if (scoredVoxels.TryGetValue(bin, out float score) && score >= threshold)
+                    {
+                        buffer.Span[bufferIndex++] = index;
+                    }
+                    index += 1ul;
+                }
+                yield return buffer.Slice(0, bufferIndex).Memory;
+            }
         }
 
         DataStateIsValid = true;
     }
-    */
 
     // On Properties panel changes, some data must be invalidated to be recomputed with new values. Invalidations depend on the properties changed
     protected override void OnPropertiesChanged(PropertyChangedEventArgs e)
@@ -685,6 +697,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         CanSave = true;
         switch (e.PropertyName)
         {
+        // Olof add cases
             case nameof(PcaProperties.Components):
                 if (Properties.Components == 0)
                 {
@@ -699,6 +712,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             case nameof(PcaProperties.Invert):
                 FilterIsInverted = Properties.Invert;
                 InvalidateSelectedComponent();
+                break;
+            case nameof(PcaProperties.NumDimsForPCAPhaseId):
+                InvalidatePcaPhases();
                 break;
             default:
                 break;
@@ -717,17 +733,28 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         EigenvalueResults = null;
         InvalidateComponents();
+        InvalidatePcaPhases();
     }
 
     private void InvalidateComponents()
     {
-        if (ColorMap is not null)
+        if (ComponentsColorMap is not null)
         {
-            Properties.ColorMap = SerializeColorMap(ColorMap);
-            ColorMap = null;
+            Properties.ComponentsColorMap = SerializeColorMap(ComponentsColorMap);
+            ComponentsColorMap = null;
         }
         ComponentsResults = null;
         InvalidateSelectedComponent();
+    }
+
+    private void InvalidatePcaPhases()
+    {
+        if (PcaColorMap is not null)
+        {
+            Properties.PcaColorMap = SerializeColorMap(PcaColorMap);
+            PcaColorMap = null;
+        }
+        PcaPhaseIDResults = null;
     }
 
     // Should actually be implemented in the base class CoreNodeBase along with existing DataStateIsValid.

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -191,7 +191,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         var compResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
 
-        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults);
+        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
+        var phaseIDResults = PcaCalculator.GetPhases(ionData, compResults, pcaPhaseIdProperties);
 
         compResults.PhaseIDResults = phaseIDResults;
 

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -697,7 +697,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         CanSave = true;
         switch (e.PropertyName)
         {
-        // Olof add cases
             case nameof(PcaProperties.Components):
                 if (Properties.Components == 0)
                 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -492,7 +492,7 @@ public class PcaScoresGrid
         // for case 2) add the voxels to the core regions
         // for case 3) designate the voxel as an interface voxel
 
-        int voxelAssignmentIterationCount = 3;
+        int voxelAssignmentIterationCount = 10;
         for (int voxelAssignmentIteration = 0; voxelAssignmentIteration < voxelAssignmentIterationCount; voxelAssignmentIteration += 1)
         {
             pcaStream.WriteTimestamp("start voxel assignment loop # " + voxelAssignmentIteration);
@@ -591,12 +591,14 @@ public class PcaScoresGrid
         // make a pcaCode to phaseIndex map:
         // 
         Dictionary<string, int> phaseIndexMap = new Dictionary<string, int>();
+        phaseIndexMap["Unassigned Voxels"] = 0;
         int phaseIndex = 1;
         foreach (string pcaCode in  pcaCodesByPopulation)
         {
             phaseIndexMap[pcaCode] = phaseIndex;
             phaseIndex += 1;
         }
+        phaseIndexMap["Interface Voxels"] = phaseIndex;
 
         // and, call IdentifyVoxelAs for each voxel
         // phaseResults initializes phase ID to zero for each voxel
@@ -605,31 +607,30 @@ public class PcaScoresGrid
         {
             phaseIdResults.IdentifyVoxelAs(voxelId, 0);
         }
-            foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in pcaCodeVoxelSets)
-            {
+        foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in pcaCodeVoxelSets)
+        {
             string nthPcaCode = kvp.Key;
-            
+
             if (phaseIndexMap.ContainsKey(nthPcaCode))
             {
                 int voxelphase = phaseIndexMap[nthPcaCode];
-                if (voxelphase > 4)
-                {
-                    voxelphase = 6;
-                }
-                foreach(VoxelID voxelId in kvp.Value)
+
+                foreach (VoxelID voxelId in kvp.Value)
                 {
                     phaseIdResults.IdentifyVoxelAs(voxelId, voxelphase);
                 }
-            }   
+            }
         }
+        phaseIdResults.SetPhaseIndexMap(phaseIndexMap);
 
         // for exery interface voxel, set it to type 5:
         //  Dictionary<string, HashSet<VoxelID>> interfaceVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
         foreach (KeyValuePair<string, HashSet<VoxelID>> kvp in interfaceVoxelSets)
         {
+            int interfaceVoxelBucket = phaseIndexMap["Interface Voxels"];
             foreach (VoxelID voxelId in kvp.Value)
             {
-                phaseIdResults.IdentifyVoxelAs(voxelId, 5);
+                phaseIdResults.IdentifyVoxelAs(voxelId, interfaceVoxelBucket);
             }
         }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -250,21 +250,38 @@ public class PcaScoresGrid
     {
         // if pcaCode contains zero 0s or more than one 0, return empty List
         HashSet<string> matches = new HashSet<string>();
-        string[] components = pcaCode.Split(".0");
-        if (components.Count() == 2)
-        {
-            // now, matching is easy -- see if both components of the split are part of a candidate code
-            // and if so, its a match.  Edge case for when the second component is zero length -- no need to check there
 
+        // tokens here means 'substrings' -- parts of the PCA code that should be matched
+        string[] tokens = pcaCode.Split(".0");
+        int numTokens = tokens.Count();
+        if (numTokens > 1)
+        {
             foreach (string candidate in nonZeroPcaCodes)
             {
-                if (candidate.Contains(components[0]) &&
-                     ((components[1].Length == 0) || candidate.Contains(components[1])))
+                bool matchesAll = true;
+                int lastTokenIndex = numTokens - 1;
+                for (int t = 0; t < lastTokenIndex; t += 1)
+                {
+                    if (!candidate.Contains(tokens[t]))
+                    {
+                        matchesAll = false;
+                    }
+                }
+                
+                // the last token might be an emptyString
+                string lastToken = tokens[lastTokenIndex];
+                if ((lastToken.Length > 0) && (!candidate.Contains(lastToken)))
+                {
+                    matchesAll = false;
+                }
+
+                if (matchesAll)
                 {
                     matches.Add(candidate);
                 }
             }
         }
+
         return matches;
     }
 
@@ -345,18 +362,18 @@ public class PcaScoresGrid
     // D) add voxels that abut any of the contiguous regions to those regions iff
     //    the code they have matches all code snippet for which they have a non-zero number
     //    i.e. A0B1C1  is a match for contiguous regions A1B1C1 and A2B1C1
-    public PhaseIdResults GetPhasesStrategyE()
+    public PhaseIdResults GetPhasesStrategyE(PcaPhaseIdentificationProperties properties)
     {
         List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
 
         // PcaStream writes a file with text data about the progression of the algorithm
         // uncomment it here and uncomment the calls to DumpVoxelSetStats below
-        // PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
-
+        PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+        pcaStream.WriteTimestamp("start GetPhasesStrategyE");
         PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
         float binSeparation = 0.5f;
-        int numDimsToInclude = Math.Min(3, this.scoreDims); // 3 for strategy D
+        int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims); 
         Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
         Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
 
@@ -382,7 +399,7 @@ public class PcaScoresGrid
                 twoDGrids[gridId] = twoDGrid;
 
                 // this identifies the peaks --  step B) above
-                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j);
+                List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j, properties);
                 partitions[gridId] = partitionedIndices;
 
                 // Enable this to get a text file with partition data
@@ -433,6 +450,7 @@ public class PcaScoresGrid
             }
         }
 
+        pcaStream.WriteTimestamp("finished making grids");
         // now examine the groups of voxels to identify contiguous regions
         // in this case, 'unassigned' means voxels not yet associated with a list of voxels in a pcaPhase
         Dictionary<string, HashSet<VoxelID>> unassignedVoxelBuckets = VoxelBuckets(pcaCodes);
@@ -450,6 +468,8 @@ public class PcaScoresGrid
 
         List<string> nonZeroPcaCodes = unassignedVoxelBuckets.Keys.Where(code => !code.Contains(".0")).ToList();
         Dictionary<string, HashSet<VoxelID>> pcaCodeVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
+        Dictionary<string, HashSet<VoxelID>> interfaceVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
+
         // pcaCodes is a Dictionary<VoxelID, string>
         foreach (string pcaCode in nonZeroPcaCodes)
         {
@@ -472,84 +492,94 @@ public class PcaScoresGrid
         // for case 2) add the voxels to the core regions
         // for case 3) designate the voxel as an interface voxel
 
-        Dictionary<string, HashSet<VoxelID>> unassignedSubtractions = new Dictionary<string, HashSet<VoxelID>>();
-        Dictionary<string, HashSet<VoxelID>> voxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
-        Dictionary<string, HashSet<VoxelID>> interfaceVoxelSets = new Dictionary<string, HashSet<VoxelID>>();
-        Dictionary<string, HashSet<VoxelID>> interfaceVoxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
-        int numNonZeroPcaCodes = nonZeroPcaCodes.Count();
-        for (int nOuter = 0; nOuter < numNonZeroPcaCodes; ++nOuter)
+        int voxelAssignmentIterationCount = 3;
+        for (int voxelAssignmentIteration = 0; voxelAssignmentIteration < voxelAssignmentIterationCount; voxelAssignmentIteration += 1)
         {
-            string nonZeroPcaCode = nonZeroPcaCodes[nOuter];
-            voxelSetAdditions[nonZeroPcaCode] = new HashSet<VoxelID>();
-        }
+            pcaStream.WriteTimestamp("start voxel assignment loop # " + voxelAssignmentIteration);
+            Dictionary<string, HashSet<VoxelID>> unassignedSubtractions = new Dictionary<string, HashSet<VoxelID>>();
+            Dictionary<string, HashSet<VoxelID>> voxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
+            Dictionary<string, HashSet<VoxelID>> interfaceVoxelSetAdditions = new Dictionary<string, HashSet<VoxelID>>();
 
-        List<string> unassignedPcaCodes = unassignedVoxelBuckets.Keys.ToList();
-        foreach (string pcaCode in unassignedPcaCodes)
-        {
-            HashSet<string> matchableCodes = filterForMatchableCode(nonZeroPcaCodes, pcaCode);
-            // matchableCodes are the nonZeroPcaCodes that are "one away" from the pcaCode under consideration
-
-            HashSet<VoxelID> potentialAdditions = unassignedVoxelBuckets[pcaCode]; 
-            HashSet<VoxelID> subtractions = new HashSet<VoxelID>();
-            List<string> matches = new List<string>(); 
-            foreach (VoxelID voxelId in potentialAdditions)
+            // this loop initializes the lists of voxels to add for each PCA code
+            int numNonZeroPcaCodes = nonZeroPcaCodes.Count();
+            for (int nOuter = 0; nOuter < numNonZeroPcaCodes; ++nOuter)
             {
-                List<VoxelID> neighbors = voxelId.NeighborVoxels(gridDims);
-                matches.Clear();
+                string nonZeroPcaCode = nonZeroPcaCodes[nOuter];
+                voxelSetAdditions[nonZeroPcaCode] = new HashSet<VoxelID>();
+            }
 
-                foreach (string matchingCode in matchableCodes)
-                {
-                    if (pcaCodeVoxelSets[matchingCode].ContainsAny(neighbors))
-                    {
-                        matches.Add(matchingCode);
-                    }
-                }
+            List<string> unassignedPcaCodes = unassignedVoxelBuckets.Keys.ToList();
+            foreach (string pcaCode in unassignedPcaCodes)
+            {
+                HashSet<string> matchableCodes = filterForMatchableCode(nonZeroPcaCodes, pcaCode);
+                // matchableCodes are the nonZeroPcaCodes that are "one away" from the pcaCode under consideration
 
-                // case 1 is no matches 
-                if (matches.Count() > 0)
+                HashSet<VoxelID> potentialAdditions = unassignedVoxelBuckets[pcaCode];
+                HashSet<VoxelID> subtractions = new HashSet<VoxelID>();
+                List<string> matches = new List<string>();
+                foreach (VoxelID voxelId in potentialAdditions)
                 {
-                    if (matches.Count() == 1)
+                    List<VoxelID> neighbors = voxelId.NeighborVoxels(gridDims);
+                    matches.Clear();
+
+                    foreach (string matchingCode in matchableCodes)
                     {
-                        voxelSetAdditions[matches[0]].Add(voxelId);
-                        subtractions.Add(voxelId);
-                    }
-                    else
-                    {
-                        string interfaceId = interfaceIdForCodes(matches);
-                        if (interfaceVoxelSetAdditions.ContainsKey(interfaceId))
+                        if (pcaCodeVoxelSets[matchingCode].ContainsAny(neighbors))
                         {
-                            interfaceVoxelSetAdditions[interfaceId].Add(voxelId);
+                            matches.Add(matchingCode);
+                        }
+                    }
+
+                    // case 1 is no matches 
+                    if (matches.Count() > 0)
+                    {
+                        if (matches.Count() == 1)
+                        {
+                            voxelSetAdditions[matches[0]].Add(voxelId);
+                            subtractions.Add(voxelId);
                         }
                         else
                         {
-                            HashSet<VoxelID> newSet = new HashSet<VoxelID>();
-                            newSet.Add(voxelId);
-                            interfaceVoxelSetAdditions[interfaceId] = newSet;
+                            string interfaceId = interfaceIdForCodes(matches);
+                            if (interfaceVoxelSetAdditions.ContainsKey(interfaceId))
+                            {
+                                interfaceVoxelSetAdditions[interfaceId].Add(voxelId);
+                            }
+                            else
+                            {
+                                HashSet<VoxelID> newSet = new HashSet<VoxelID>();
+                                newSet.Add(voxelId);
+                                interfaceVoxelSetAdditions[interfaceId] = newSet;
+                            }
+                            subtractions.Add(voxelId);
                         }
-                        subtractions.Add(voxelId);
                     }
                 }
+                unassignedSubtractions[pcaCode] = subtractions;
             }
-            unassignedSubtractions[pcaCode] = subtractions;
+            // now, any voxel that is part of interfaceVoxelSetAdditions
+            // or voxelSetAdditions should get taken out of unassignedVoxelBuckets
+            // and added to interfaceVoxelSets or pcaCodeVoxelSets
+
+            // calls to DumpVoxelSetStats are used to follow the progression of the algorithm is assigning voxels
+            // these can be enabled if the pcaStream object is created above
+
+            pcaStream.WriteTimestamp("finished voxel partitioning" );
+            pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets); 
+            pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
+            pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
+            pcaStream.DumpVoxelSetStats("voxelSetAdditions", voxelSetAdditions);
+            pcaStream.DumpVoxelSetStats("interfaceVoxelSetAdditions", interfaceVoxelSetAdditions);
+
+            addVoxelsToHashSetDictionary(interfaceVoxelSetAdditions, interfaceVoxelSets);
+            addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
+            subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
+
+            pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
+            pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
+            pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
+            pcaStream.WriteTimestamp("finished voxel loop");
         }
-        // now, any voxel that is part of interfaceVoxelSetAdditions
-        // or voxelSetAdditions should get taken out of unassignedVoxelBuckets
-        // and added to interfaceVoxelSets or pcaCodeVoxelSets
-
-        // calls to DumpVoxelSetStats are used to follow the progression of the algorithm is assigning voxels
-        // these can be enabled if the pcaStream object is created above
-        // pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
-        // pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
-        // pcaStream.DumpVoxelSetStats("voxelSetAdditions", voxelSetAdditions);
-        // pcaStream.DumpVoxelSetStats("interfaceVoxelSetAdditions", interfaceVoxelSetAdditions);
-
-        addVoxelsToHashSetDictionary(interfaceVoxelSetAdditions, interfaceVoxelSets);
-        addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
-        subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
-
-        // pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
-        // pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
-        // pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
 
         // now, pcaCodeVoxelSets is ready to be used for define a per-voxel component mapping
         // lets order the pcaCodeVoxelSets by population
@@ -603,7 +633,7 @@ public class PcaScoresGrid
             }
         }
 
-        // pcaStream.Close();
+        pcaStream.Close();
         return phaseIdResults;
     }
 
@@ -615,7 +645,7 @@ public class PcaScoresGrid
     // If it does, add it to the appropriate list
     // return the list of lists
     // indices not identified are not returned in any list
-    public List<List<PixelID>> IdentifyPartitions(DensityPlane twoDGrid, int dimX, int dimy)
+    public List<List<PixelID>> IdentifyPartitions(DensityPlane twoDGrid, int dimX, int dimy, PcaPhaseIdentificationProperties props)
     {
         // to identify the first maximum, just find the pixel with the highest value
         // then, accumulate neighboring pixels, avoiding neighbors with higher values
@@ -628,9 +658,9 @@ public class PcaScoresGrid
 
         // partitionFinder operates on the grid, identifying pixels
         // associated with the different maxima
-        TwoDGridPartitionFinder partitionFinder = new TwoDGridPartitionFinder(twoDGrid);
+        TwoDGridPartitionFinder partitionFinder = new TwoDGridPartitionFinder(twoDGrid, props);
 
-        partitionFinder.FindPartitions(0.1f);
+        partitionFinder.FindPartitions(props.noiseFloorFraction);
         var pixelLists = partitionFinder.GetPixelLists();
         partitionFinder.Clear();
         return pixelLists;

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System;
 using PcaExtensionMethods;
+using Cameca.CustomAnalysis.Pca;
 
 
 public class TwoDGridPartitionFinder
@@ -12,6 +13,7 @@ public class TwoDGridPartitionFinder
     List<PixelID> rejectedPixelIds;
     List<PixelID> foundIncreasePixelIds; // when a peak finds an increase, remember it here
     Dictionary<PeakID, TwoDPeak> peaks;
+    PcaPhaseIdentificationProperties properties;
 
     // These are the return codes returned by IterateIdentifyingPeaks()
     // Depending on this result, the Logic in FindPartitions will either
@@ -24,13 +26,18 @@ public class TwoDGridPartitionFinder
         exhaustedSuggestions
     }
 
-    public TwoDGridPartitionFinder(DensityPlane twoDGrid)
+    public float PeakSummitAllowance()
+    {
+        return properties.peakSummitAllowance;
+    }
+    public TwoDGridPartitionFinder(DensityPlane twoDGrid, PcaPhaseIdentificationProperties props)
     {
         this.grid = twoDGrid;
         this.peaks = new Dictionary<PeakID, TwoDPeak> ();
         this.rejectedPixelIds = new List<PixelID>();
         this.foundIncreasePixelIds = new List<PixelID>();
         this.unplacedPixelIds = twoDGrid.GridPointIds();
+        this.properties = props;
     }
 
     // for each iteration step,

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -93,7 +93,7 @@ public class TwoDPeak
     List<PixelID> foundIncreaseIds; // list of pixelIds at edge which increase relative to neighbor
     TwoDGridPartitionFinder partitionFinder; // will supply available neighbors
     float peakValue;
-    float peakAgglomerationFraction;  // the value above which to ignore 'second peak'
+    float summitAllowance;  // the value above which to ignore 'second peak'
 
     public TwoDPeak(TwoDGridPartitionFinder partitionFinder, DensityPlane grid, PixelID peakMaxPixelId)
     {
@@ -106,7 +106,7 @@ public class TwoDPeak
         this.topCandidates = new List<PixelSuggestion>();
         this.referenceGrid = grid;
         this.foundIncreaseIds = new List<PixelID>();
-        this.peakAgglomerationFraction = 0.8f; // hard code this value
+        this.summitAllowance = partitionFinder.PeakSummitAllowance(); // hard code this value
 
         this.peakValue = grid.valueAtPixel(peakMaxPixelId);
         PixelSuggestion firstSuggestion = new PixelSuggestion(peakId, peakMaxPixelId, this.peakValue);
@@ -147,7 +147,7 @@ public class TwoDPeak
                 float neighborScore = referenceGrid.valueAtPixel(availableId);
 
                 // for now, hard code 
-                if ((neighborScore > suggestion.score) && (suggestion.score < this.peakValue * this.peakAgglomerationFraction))
+                if ((neighborScore > suggestion.score) && (suggestion.score < this.peakValue * this.summitAllowance))
                 {
                     // neighbor has higher score -- shouldn't add to current peak
                     // the currently 'accepted suggestion' is actually a pixel between peaks.


### PR DESCRIPTION
This commit contains better visualization for the PCA phases steps, and more control parameters for users to specify how the PCA phase identification is done.  

Some more separation is made between the "Components" calculation and the "PCA Phase Identification" steps.  This means user first updates the Components under the components tab, then clicks the Update button again under the PCA Phases tab.  I hope to streamline this in a subsequent PR.

Among the new controls:

Detached ROI can be done either based on PCA Phase or on the PCA component value.  The new check box in the properties pane switches between the two.  If "Use PCA phase" is checked, the PCA Phase in the PCA Phase Index box is used, otherwise, the Component Index is used.

Number of PCA dimensions used controls how many grids are made -- i.e. if 3 dimensions are used, 3 grids are made -- if 4 dimensions are used, 6 grids are made.

Also, fixed the unfortunate linking between the color maps for the two displays, and specified the names for the different PCA phases in the display.

