### PR TITLE
Include jitter ("Components Render Noise") in PCA phase display

### DIFF
--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -388,10 +388,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             TwoDPeakProjections: Dictionary<string, TwoDPeakProjection> twoDPeakProjections,
             PhaseIndexMap: Dictionary<PcaPhaseName, int> phaseIndexMap } )
      
-         {   
-             PcaPhasesRenderData = Array.Empty<IRenderData>();
+        {   
+            PcaPhasesRenderData = Array.Empty<IRenderData>();
 
-             Dictionary<int, PcaPhaseName> phaseNamesMap = PcaPhaseIDResults.PhaseNamesMap();
+            var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
+
+            Dictionary<int, PcaPhaseName> phaseNamesMap = PcaPhaseIDResults.PhaseNamesMap();
              int numPhases = phaseNamesMap.Count; 
              // int selectedIndex = Properties.ComponentIndex;
 
@@ -403,7 +405,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
                 // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
                 // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
-                var positionsWithValues = PositionScores.GetScoredPositions(ComponentsResults.Grid3DData, ComponentsResults.VoxelIndices, phaseIdScores);
+                var positionsWithValues = PositionScores.GetScoredPositions(ComponentsResults.Grid3DData, ComponentsResults.VoxelIndices, phaseIdScores, jitterStdDev: jitterStdDev);
 
                 var valuePoints = Resources.ChartObjects.CreateValuePoints();
         

--- a/Cameca.CustomAnalysis.Pca/Utils/PositionScores.cs
+++ b/Cameca.CustomAnalysis.Pca/Utils/PositionScores.cs
@@ -8,8 +8,6 @@ internal static class PositionScores
 {
     public static Vector4[] GetScoredPositions(IGrid3DData gridData, int[] voxelIndices, float[] scores, float jitterStdDev = 0f)
     {
-
-
         int xVoxels = gridData.NumVoxels[0];
         double xSize = gridData.VoxelSize[0];
         double xStart = gridData.GridRange[0, 0] + (xSize / 2d);


### PR DESCRIPTION
The "Components Render Noise" parameter is set via 

   Configuration -> Options -> Extension Options / Principal Component Analysis

It adjusts the visualization so that voxel positions are randomly positioned near their centers, but not exactly at the center, so as to avoid much of the Moire patterns resulting from alignment of the grid at or mean a symmetry pole.

This PR hooks up the PCA phase visualization to this jitter parameter.