### PR TITLE
Add ability to exclude specific grids from the PCA phase identification step

### DIFF
--- a/Cameca.CustomAnalysis.Pca/Interfaces/GridsUsageDelegate.cs
+++ b/Cameca.CustomAnalysis.Pca/Interfaces/GridsUsageDelegate.cs
@@ -1,0 +1,29 @@
+﻿using Cameca.CustomAnalysis.Interface;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Cameca.CustomAnalysis.Pca;
+
+
+public interface IGridsUsageDelegate
+{
+    void UseGridForPca(string gridID, bool useIt);
+    bool UsesGridForPca(string gridID);
+}
+
+public class DoNothingGridsUsageDelegate : IGridsUsageDelegate 
+{
+    public DoNothingGridsUsageDelegate()
+    {
+    }
+
+    public void UseGridForPca(string gridID, bool useIt)
+    {
+
+    }
+
+    public bool UsesGridForPca(string gridID)
+    {
+        return true;
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/Models/PhaseIDResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/PhaseIDResults.cs
@@ -3,15 +3,12 @@ using System.Linq;
 using System;
 using Cameca.CustomAnalysis.Pca;
 
-
-
 // PhaseIDResults represents an assignment of each voxel to an integer phase.
 // in the identifiedPhase Dictionary, the Key is a VoxelID, and the value is its 'phase', 
 // or 0 if no phase is identified
 public class PhaseIdResults
 {
     public Dictionary<VoxelID, int> IdentifiedPhase;
-    public Dictionary<string, TwoDPeakProjection> TwoDPeakProjections;
     public Dictionary<PcaPhaseName, int> PhaseIndexMap; // the values in identifiedPhase dictionary should correspond to the PCA codes in this list
                                            // there should be an entry "0" with the key "Unassigned Voxels"
                                            // there should be an entry N with the key "Interface Voxels" -- the index with the greatest value
@@ -25,7 +22,6 @@ public class PhaseIdResults
         {
             this.IdentifiedPhase[voxelIds[i]] = 0;
         }
-        this.TwoDPeakProjections = new Dictionary<string, TwoDPeakProjection>();
         this.PhaseIndexMap = new Dictionary<PcaPhaseName, int>();
     }
 
@@ -39,11 +35,6 @@ public class PhaseIdResults
         }
 
         return namesMap;
-    }
-
-    public void SetTwoDPeakProjectionFor(string key, TwoDPeakProjection projection)
-    {
-        TwoDPeakProjections[key] = projection;
     }
 
     public void IdentifyVoxelAs(VoxelID voxelId, int phase)

--- a/Cameca.CustomAnalysis.Pca/Models/TwoDGridsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/TwoDGridsResults.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using Cameca.CustomAnalysis.Pca;
+// TwoDGridsResults represents the projection of the PCA Components results
+// onto two dimensional drids for different pairs of axes
+public class TwoDGridsResults
+{
+    // key in these dictionaries is gridID
+    public Dictionary<TwoDGridID, TwoDPeakProjection> TwoDPeakProjections;
+ 
+    public TwoDGridsResults()
+    {
+        this.TwoDPeakProjections = new Dictionary<TwoDGridID, TwoDPeakProjection>();
+     }
+
+    public void SetTwoDPeakProjectionFor(TwoDGridID key, TwoDPeakProjection projection)
+    {
+        TwoDPeakProjections[key] = projection;
+    }
+
+}
+    
+  

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -11,12 +11,20 @@ public delegate float[] GetScoresDelegate(int voxelIndex);
 
 public struct PcaPhaseIdentificationProperties
 {
+    public float gridProjectionBinSize;
+    public float gridProjectionDelocalization;
     public float noiseFloorFraction;
     public float peakSummitAllowance;
     public int numDimsForPCAPhaseId;
 
-    public PcaPhaseIdentificationProperties(float noiseFloor, float peakSummitAllowance, int numDimsForPCAPhaseId)
+    public PcaPhaseIdentificationProperties(float gridProjectionBinSize,
+          float gridProjectionDelocalization,
+          float noiseFloor, 
+          float peakSummitAllowance, 
+          int numDimsForPCAPhaseId)
     {
+        this.gridProjectionBinSize = gridProjectionBinSize;
+        this.gridProjectionDelocalization = gridProjectionDelocalization;
         this.noiseFloorFraction = noiseFloor;
         this.peakSummitAllowance = peakSummitAllowance;
         this.numDimsForPCAPhaseId = numDimsForPCAPhaseId;

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -80,7 +80,6 @@ internal static class PcaCalculator
     private const float ScoresCoefficient = 1000f;
     private const float LoadingsCoefficient = 0.001f;
 
-
     public static EigenvalueResults GetEignevalues(IIonData ionData, IGrid3DData gridData)
     {
         int nAllVoxels = gridData.NumVoxels[0] * gridData.NumVoxels[1] * gridData.NumVoxels[2];

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -55,7 +55,7 @@ public class PcaScoresGridProducer: IScoresProvider {
         return (voxelId, scores);
     }
 
-    public PcaScoresGrid ScoresGrid()
+    public PcaScoresGrid GenerateScoresGrid()
     {
         int nComponents = compResults.Components.Count;
 
@@ -81,6 +81,7 @@ internal static class PcaCalculator
      */
     private const float ScoresCoefficient = 1000f;
     private const float LoadingsCoefficient = 0.001f;
+
 
     public static EigenvalueResults GetEignevalues(IIonData ionData, IGrid3DData gridData)
     {
@@ -125,14 +126,16 @@ internal static class PcaCalculator
     }
 
     // manipulate the results of PCA to identify phases per voxel
-    public static PhaseIdResults GetPhases(IIonData ionData, ComponentsResults compResults, PcaPhaseIdentificationProperties properties)
+    public static PcaScoresGrid GenerateScoresGrid(IIonData ionData, ComponentsResults compResults, PcaPhaseIdentificationProperties properties)
     {
-        // make a PcaGrid, then call grid.GetPhases
         PcaScoresGridProducer producer = new PcaScoresGridProducer(compResults, properties);
 
-        PcaScoresGrid scoresGrid = producer.ScoresGrid();
-        return scoresGrid.GetPhasesStrategyE(properties);
-    }
+        return producer.GenerateScoresGrid();
+    }     // manipulate the results of PCA to identify phases per voxel
+    public static TwoDGridsResults CalculateTwoDGrids(PcaScoresGrid scoresGrid, PcaPhaseIdentificationProperties properties)
+    {
+        return scoresGrid.CalculateTwoDGrids(properties);
+    }    // manipulate the results of PCA to identify phases per voxel
 
     public static NoiseEigenvalueResults GetNoiseEigenvalues(float[] evals, int gaps, int significance, bool refine)
     {

--- a/Cameca.CustomAnalysis.Pca/PcaProperties.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaProperties.cs
@@ -36,7 +36,8 @@ public partial class PcaProperties : ObservableObject
     private bool refine = true;
 
     [ObservableProperty]
-    private int components = 0;
+    [field: Display(Name = "Components")]
+    private int numberOfComponents = 0;
 
     [ObservableProperty]
     [field:Display(Name = "Component Index")]
@@ -71,10 +72,6 @@ public partial class PcaProperties : ObservableObject
     [ObservableProperty]
     [field: Display(Name = "Peak Summit Allowance")]
     private float peakSummitAllowance = 0.8f;
-
-    [ObservableProperty]
-    [field: Display(Name = "PCA Phase Id Dimensions")]
-    private int numDimsForPCAPhaseId = 3;
 
     [ObservableProperty]
     [field: Display(Name = "PCA Phase Index")]

--- a/Cameca.CustomAnalysis.Pca/PcaProperties.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaProperties.cs
@@ -57,7 +57,15 @@ public partial class PcaProperties : ObservableObject
     private bool invert = false;
 
     [ObservableProperty]
-    [field: Display(Name = "Noise Floor")]
+    [field: Display(Name = "Grid Projection Bin Size")]
+    private float gridProjectionBinSize = 0.5f;
+
+    [ObservableProperty]
+    [field: Display(Name = "Grid Projection Delocalization")]
+    private float gridProjectionDelocalization = 0.25f;
+
+    [ObservableProperty]
+    [field: Display(Name = "Peak ID Noise Floor")]
     private float noiseFloorFraction = 0.1f;
 
     [ObservableProperty]

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -102,6 +102,15 @@
                 </utils:ButtonOverlayControl>
             </TabItem>
 
+            <TabItem Header="Grids">
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
+                               ButtonContent="Update"
+                               OverlayVisibility="{Binding UpdatePCAPhasesCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}" />
+
+                </utils:ButtonOverlayControl>
+            </TabItem>
+            
             <TabItem Header="PCA Phases">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
                                 ButtonContent="Update"
@@ -124,15 +133,6 @@
                                                   ItemsSource="{Binding PcaPhasesRenderData}" />
 
                     </Grid>
-                </utils:ButtonOverlayControl>
-            </TabItem>
-
-            <TabItem Header="Grids">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
-                               ButtonContent="Update"
-                               OverlayVisibility="{Binding UpdatePCAPhasesCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}" />
-
                 </utils:ButtonOverlayControl>
             </TabItem>
 

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -103,14 +103,14 @@
             </TabItem>
 
             <TabItem Header="Grids">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateGridsCommand}"
                                ButtonContent="Update"
-                               OverlayVisibility="{Binding UpdatePCAPhasesCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}" />
-
+                               OverlayVisibility="{Binding UpdateGridsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <local:ProjectionGridsView GridsSource="{Binding SelectedGridRenderData}"   
+                                               GridsUsageDelegate="{Binding GridsUsageDelegate}" />
                 </utils:ButtonOverlayControl>
             </TabItem>
-            
+
             <TabItem Header="PCA Phases">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdatePCAPhasesCommand}"
                                 ButtonContent="Update"
@@ -161,7 +161,7 @@
                     </lvc:CartesianChart>
                 </utils:ButtonOverlayControl>
             </TabItem>
-            
+
             <TabItem Header="Scores">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
                             ButtonContent="Update"

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -63,7 +63,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateComponentsCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateComponentsCommand))]
-    private ComponentsResults? componentsResults;
+    private ComponentsResults? pcaComponentsResults; 
+
+    [ObservableProperty]
+    private PcaScoresGrid? scoresGrid = null;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateGridsCanExecute))]
@@ -91,7 +94,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
     public ICollection<IRenderData> scoresHistogramData = Array.Empty<IRenderData>();
 
-    public bool UpdateComponentsCanExecute => ComponentsResults is null;
+    public bool UpdateComponentsCanExecute => PcaComponentsResults is null;
     public bool UpdateGridsCanExecute => PcaGridsResults is null;
     public bool UpdatePCAPhasesCanExecute => PcaPhaseIDResults is null;
 
@@ -203,9 +206,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             return;
         }
 
-        var compResults = PcaCalculator.GetComponents(ionData, gridData, Properties.Components);
-
-        ComponentsResults = compResults;
+        PcaComponentsResults = PcaCalculator.GetComponents(ionData, gridData, Properties.NumberOfComponents);
 
         UpdateOptionsBounds();
 
@@ -214,9 +215,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         {
             Properties.ComponentIndex = 0;
         }
-        else if (Properties.ComponentIndex > Properties.Components)
+        else if (Properties.ComponentIndex > Properties.NumberOfComponents)
         {
-            Properties.ComponentIndex = Properties.Components;
+            Properties.ComponentIndex = Properties.NumberOfComponents;
         }
 
         await UpdateSelectedComponent(cancellationToken);
@@ -226,13 +227,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     // or if any of the properties to use in the calculation change
     [RelayCommand(CanExecute = nameof(UpdateGridsCanExecute))]
     public async Task UpdateGrids(CancellationToken cancellationToken)
-    {
-    }
-    
-    // PCA Phases can be updated independently of the Components and grids   if the number of grids to use changes
-    // or if any of the properties to use in the calculation change
-    [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
-    public async Task UpdatePCAPhases(CancellationToken cancellationToken)
     {
         DataStateIsError = false;
         if (await Resources.GetIonData(cancellationToken: cancellationToken) is not { } ionData)
@@ -247,23 +241,31 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             DataStateIsError = true;
             return;
         }
+        
+        var compResults = PcaComponentsResults;
 
-        var compResults = ComponentsResults;
-
-        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
-        PcaPhaseIDResults = PcaCalculator.GetPhases(ionData, compResults, pcaPhaseIdProperties);
-
-        // Ensure that the selected component falls in the valid range of number of components
-        if (Properties.ComponentIndex < 0)
+        if (compResults != null)
         {
-            Properties.ComponentIndex = 0;
+            var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
+            ScoresGrid = PcaCalculator.GenerateScoresGrid(ionData, compResults, pcaPhaseIdProperties); 
+            PcaGridsResults = PcaCalculator.CalculateTwoDGrids(ScoresGrid, pcaPhaseIdProperties);
         }
-        else if (Properties.ComponentIndex > Properties.Components)
-        {
-            Properties.ComponentIndex = Properties.Components;
-        }
+    }
+    
+    // PCA Phases can be updated independently of the Components and grids   if the number of grids to use changes
+    // or if any of the properties to use in the calculation change
+    [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
+    public async Task UpdatePCAPhases(CancellationToken cancellationToken)
+    {
 
-        await UpdateSelectedComponent(cancellationToken);
+        var scoresGrid = ScoresGrid;
+        var gridsResults = PcaGridsResults;
+
+        if ((scoresGrid != null) && (gridsResults != null))
+        {
+            var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
+            PcaPhaseIDResults = scoresGrid.GetPhasesStrategyE(pcaPhaseIdProperties);
+        }
     }
 
     // Uses the component data (or computes for all componets if necessary) to generate plots for the selected component by index
@@ -279,13 +281,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             return;
         }
 
-        int numComponents = Properties.Components;
+        int numComponents = Properties.NumberOfComponents;
         int selectedIndex = Properties.ComponentIndex;
         
-        if (ComponentsResults is null){
+        if (PcaComponentsResults is null){
             await UpdateComponents(cancellationToken);
         }
-        if (ComponentsResults?.Components.ElementAtOrDefault(selectedIndex) is not { Scores: { } scores, Loads: { } loadingData })
+        if (PcaComponentsResults?.Components.ElementAtOrDefault(selectedIndex) is not { Scores: { } scores, Loads: { } loadingData })
         {
             return;
         }
@@ -373,9 +375,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         if (NoiseEigenvalueResults is { Rank: int rank, NoiseEvals: float[] noiseEvals })
         {
-            if (Properties.Components == 0)
+            if (Properties.NumberOfComponents == 0)
             {
-                Properties.Components = rank;
+                Properties.NumberOfComponents = rank;
             }
             if (EigenvalueRenderData.FirstOrDefault(x => x.Name == "Noise Eigenvalues") is { } noiseEigenvalues)
             {
@@ -399,24 +401,25 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         if (PcaPhaseIDResults is { IdentifiedPhase: Dictionary<VoxelID, int> identifiedPhase,
             PhaseIndexMap: Dictionary<PcaPhaseName, int> phaseIndexMap } )
+
         {   
             PcaPhasesRenderData = Array.Empty<IRenderData>();
 
             var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 
             Dictionary<int, PcaPhaseName> phaseNamesMap = PcaPhaseIDResults.PhaseNamesMap();
-             int numPhases = phaseNamesMap.Count; 
-             // int selectedIndex = Properties.ComponentIndex;
-
+             int numPhases = phaseNamesMap.Count;
+            // int selectedIndex = Properties.ComponentIndex;
+ 
             var newPhasesData = new IRenderData[numPhases];
             IValuePointsRenderData? rootValuePoints2 = null;
             for (int compIndex = 0; compIndex < numPhases; compIndex++)
             {
-                var phaseIdScores = GetPhaseIdScoresForVoxelIndices(PcaPhaseIDResults, compIndex, ComponentsResults.VoxelIndices);
+                var phaseIdScores = GetPhaseIdScoresForVoxelIndices(PcaPhaseIDResults, compIndex, PcaComponentsResults.VoxelIndices);
 
                 // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
                 // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
-                var positionsWithValues = PositionScores.GetScoredPositions(ComponentsResults.Grid3DData, ComponentsResults.VoxelIndices, phaseIdScores, jitterStdDev: jitterStdDev);
+                var positionsWithValues = PositionScores.GetScoredPositions(PcaComponentsResults.Grid3DData, PcaComponentsResults.VoxelIndices, phaseIdScores, jitterStdDev: jitterStdDev);
 
                 var valuePoints = Resources.ChartObjects.CreateValuePoints();
         
@@ -468,12 +471,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
     }
     // Updates the components 3D plots when the component data (derived from selected number of components) changes
-    partial void OnComponentsResultsChanged(ComponentsResults? value)
+    partial void OnPcaComponentsResultsChanged(ComponentsResults? value)
     {
         ComponentRenderData = Array.Empty<IRenderData>();
         SelectedGridRenderData = Array.Empty<IRenderData>();
 
-        if (ComponentsResults is not { Grid3DData: { } gridData,
+        if (PcaComponentsResults is not { Grid3DData: { } gridData,
             Components: { } components,
             VoxelIndices: { } voxelIndices }
          || Resources.GetValidIonData() is not { } ionData)
@@ -481,7 +484,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             return;
         }
 
-        int numComponents = Properties.Components;
+        int numComponents = Properties.NumberOfComponents;
         int selectedIndex = Properties.ComponentIndex;
 
         var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
@@ -620,7 +623,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     // Updates readonly Min/Max properties so the bounds are displayed in the Properties panel 
     private void UpdateOptionsBounds()
     {
-        var selectedResult = ComponentsResults?.Components.ElementAtOrDefault(Properties.ComponentIndex);
+        var selectedResult = PcaComponentsResults?.Components.ElementAtOrDefault(Properties.ComponentIndex);
         Properties.Min = selectedResult?.Scores.Min();
         Properties.Max = selectedResult?.Scores.Max();
     }
@@ -632,14 +635,14 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
 
         DataStateIsError = false;
-        if (ComponentsResults is null)
+        if (PcaComponentsResults is null)
         {
             await UpdateComponents(cancellationToken);
         }
 
         // Extract necessary data out of ComponentsResults using some pattern matching for null checks and variable assignment
-        if (ComponentsResults is not { Grid3DData: { } gridData, VoxelIndices: { } nonEmptyVoxels }
-            || ComponentsResults.Components[Properties.ComponentIndex] is not { Scores: { } scores })
+        if (PcaComponentsResults is not { Grid3DData: { } gridData, VoxelIndices: { } nonEmptyVoxels }
+            || PcaComponentsResults.Components[Properties.ComponentIndex] is not { Scores: { } scores })
         {
             DataStateIsError = true;
             yield break;
@@ -720,12 +723,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         CanSave = true;
         switch (e.PropertyName)
         {
-            case nameof(PcaProperties.Components):
-                if (Properties.Components == 0)
+            case nameof(PcaProperties.NumberOfComponents):
+                if (Properties.NumberOfComponents == 0)
                 {
                     NoiseEigenvalueResults = null;
                 }
-                InvalidateComponents();
+                InvalidatePcaComponents();
                 break;
             case nameof(PcaProperties.ComponentIndex):
                 UpdateOptionsBounds();
@@ -735,8 +738,17 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
                 FilterIsInverted = Properties.Invert;
                 InvalidateSelectedComponent();
                 break;
-            case nameof(PcaProperties.NumDimsForPCAPhaseId):
-                InvalidatePcaPhases();
+            case nameof(PcaProperties.GridProjectionBinSize):
+                InvalidatePcaGrids();
+                break;
+            case nameof(PcaProperties.GridProjectionDelocalization):
+                InvalidatePcaGrids();
+                break;
+            case nameof(PcaProperties.NoiseFloorFraction):
+                InvalidatePcaGrids();
+                break;
+            case nameof(PcaProperties.PeakSummitAllowance):
+                InvalidatePcaGrids();
                 break;
             default:
                 break;
@@ -754,19 +766,28 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private void InvalidateAll()
     {
         EigenvalueResults = null;
-        InvalidateComponents();
+        InvalidatePcaComponents();
         InvalidatePcaPhases();
     }
 
-    private void InvalidateComponents()
+    private void InvalidatePcaGrids()
+    {
+        PcaGridsResults = null;
+        InvalidatePcaPhases();
+    }
+
+    private void InvalidatePcaComponents()
     {
         if (ComponentsColorMap is not null)
         {
             Properties.ComponentsColorMap = SerializeColorMap(ComponentsColorMap);
             ComponentsColorMap = null;
         }
-        ComponentsResults = null;
+
+        InvalidatePcaGrids();
+        PcaComponentsResults = null;
         InvalidateSelectedComponent();
+
     }
 
     private void InvalidatePcaPhases()

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -66,6 +66,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private ComponentsResults? componentsResults;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateGridsCanExecute))]
+    [NotifyCanExecuteChangedFor(nameof(UpdateGridsCommand))]
+    private TwoDGridsResults? pcaGridsResults;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdatePCAPhasesCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdatePCAPhasesCommand))]
     private PhaseIdResults? pcaPhaseIDResults;
@@ -87,6 +92,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     public ICollection<IRenderData> scoresHistogramData = Array.Empty<IRenderData>();
 
     public bool UpdateComponentsCanExecute => ComponentsResults is null;
+    public bool UpdateGridsCanExecute => PcaGridsResults is null;
     public bool UpdatePCAPhasesCanExecute => PcaPhaseIDResults is null;
 
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
@@ -217,6 +223,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     // PCA Phases can be updated independently of the Components if the number of grids to use changes
+    // or if any of the properties to use in the calculation change
+    [RelayCommand(CanExecute = nameof(UpdateGridsCanExecute))]
+    public async Task UpdateGrids(CancellationToken cancellationToken)
+    {
+    }
+    
+    // PCA Phases can be updated independently of the Components and grids   if the number of grids to use changes
     // or if any of the properties to use in the calculation change
     [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
     public async Task UpdatePCAPhases(CancellationToken cancellationToken)
@@ -385,12 +398,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     partial void OnPcaPhaseIDResultsChanged(PhaseIdResults? value)
     {
         if (PcaPhaseIDResults is { IdentifiedPhase: Dictionary<VoxelID, int> identifiedPhase,
-            TwoDPeakProjections: Dictionary<string, TwoDPeakProjection> twoDPeakProjections,
             PhaseIndexMap: Dictionary<PcaPhaseName, int> phaseIndexMap } )
-     
         {   
             PcaPhasesRenderData = Array.Empty<IRenderData>();
-            SelectedGridRenderData = Array.Empty<IRenderData>();
 
             var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 
@@ -433,12 +443,23 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             }
 
             PcaPhasesRenderData = newPhasesData;
+
+        }
+    }
+
+    partial void OnPcaGridsResultsChanged(TwoDGridsResults? value)
+    {
+        if (PcaGridsResults is {
+                TwoDPeakProjections: Dictionary<TwoDGridID, TwoDPeakProjection> twoDPeakProjections
+            })
+        {
+            SelectedGridRenderData = Array.Empty<IRenderData>();
             int gridCount = twoDPeakProjections.Count;
             var newGridProjectionsData = new List<IRenderData>();
-            foreach (KeyValuePair<string, TwoDPeakProjection> kvp in twoDPeakProjections)
+            foreach (KeyValuePair<TwoDGridID, TwoDPeakProjection> kvp in twoDPeakProjections)
             {
                 var histogram = Resources.ChartObjects.CreateHistogram2D();
-                histogram.Name = kvp.Key;
+                histogram.Name = kvp.Key.ToString();
                 histogram.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
                 FillRenderDataWithGridData(histogram, kvp.Value);
                 newGridProjectionsData.Add(histogram);
@@ -446,7 +467,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             SelectedGridRenderData = newGridProjectionsData;
         }
     }
-
     // Updates the components 3D plots when the component data (derived from selected number of components) changes
     partial void OnComponentsResultsChanged(ComponentsResults? value)
     {

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -237,7 +237,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         var compResults = ComponentsResults;
 
-        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
+        var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumDimsForPCAPhaseId);
         PcaPhaseIDResults = PcaCalculator.GetPhases(ionData, compResults, pcaPhaseIdProperties);
 
         // Ensure that the selected component falls in the valid range of number of components
@@ -390,6 +390,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
      
         {   
             PcaPhasesRenderData = Array.Empty<IRenderData>();
+            SelectedGridRenderData = Array.Empty<IRenderData>();
 
             var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -22,11 +22,12 @@ using System.Windows.Markup;
 using System.Runtime.Intrinsics.Arm;
 using Cameca.Extensions.Controls;
 using Cameca.CustomAnalysis.Pca;
+using System.Xaml;
 
 namespace Cameca.CustomAnalysis.Pca;
 
 [DefaultView(PcaViewModel.UniqueId, typeof(PcaViewModel))]
-internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaProperties>
+internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaProperties>, IGridsUsageDelegate
 {
     private readonly INodeDataProvider nodeDataProvider;
     private readonly IOptionsAccessor optionsAccessor;
@@ -50,6 +51,9 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
     [ObservableProperty]
     private ICollection<IRenderData> selectedGridRenderData = Array.Empty<IRenderData>();
+
+    [ObservableProperty]
+    private IGridsUsageDelegate gridsUsageDelegate = new DoNothingGridsUsageDelegate();
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(UpdateCommand))]
@@ -105,6 +109,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
     public Func<double, string> AxisYLabelFormatter { get; } = (double value) => value.ToString("F3");
 
+    internal HashSet<string> gridsToExcludeFromPCA = new HashSet<string>();
     public PrincipalComponentAnalysis(
         IStandardAnalysisFilterNodeBaseServices services,
         ResourceFactory resourceFactory,
@@ -114,6 +119,24 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         this.nodeDataProvider = nodeDataProvider;
         this.optionsAccessor = optionsAccessor;
+        this.gridsUsageDelegate = this;
+    }
+
+    public bool UsesGridForPca(string gridID)
+    {
+        return !gridsToExcludeFromPCA.Contains(gridID);
+    }
+    public void UseGridForPca(string gridID, bool useIt)
+    {
+        if (useIt)
+        {
+            gridsToExcludeFromPCA.Remove(gridID);
+        }
+        else
+        {
+            gridsToExcludeFromPCA.Add(gridID);
+        }
+        InvalidatePcaPhases();
     }
 
     protected override byte[]? GetSaveContent()
@@ -264,7 +287,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         if ((scoresGrid != null) && (gridsResults != null))
         {
             var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
-            PcaPhaseIDResults = scoresGrid.GetPhasesStrategyE(pcaPhaseIdProperties);
+            PcaPhaseIDResults = scoresGrid.GetPhasesStrategyE(pcaPhaseIdProperties, gridsToExcludeFromPCA);
         }
     }
 

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -404,7 +404,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         {   
             PcaPhasesRenderData = Array.Empty<IRenderData>();
-
+            var voxelIndices = PcaComponentsResults.VoxelIndices;
+            if (voxelIndices is null) 
+            {
+                return;
+            }
             var jitterStdDev = optionsAccessor.GetOptions<PcaGlobalOptions>().JitterStdDev;
 
             Dictionary<int, PcaPhaseName> phaseNamesMap = PcaPhaseIDResults.PhaseNamesMap();
@@ -415,11 +419,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             IValuePointsRenderData? rootValuePoints2 = null;
             for (int compIndex = 0; compIndex < numPhases; compIndex++)
             {
-                var phaseIdScores = GetPhaseIdScoresForVoxelIndices(PcaPhaseIDResults, compIndex, PcaComponentsResults.VoxelIndices);
+                var phaseIdScores = GetPhaseIdScoresForVoxelIndices(PcaPhaseIDResults, compIndex, voxelIndices);
 
                 // data fed into GetScoredPositions is an array of voxelIndices for which a dot should be generated,
                 // and an array of scores -- scores[n] is the score for the voxel at voxelIndex[n]
-                var positionsWithValues = PositionScores.GetScoredPositions(PcaComponentsResults.Grid3DData, PcaComponentsResults.VoxelIndices, phaseIdScores, jitterStdDev: jitterStdDev);
+                var positionsWithValues = PositionScores.GetScoredPositions(PcaComponentsResults.Grid3DData, voxelIndices, phaseIdScores, jitterStdDev: jitterStdDev);
 
                 var valuePoints = Resources.ChartObjects.CreateValuePoints();
         

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
@@ -19,8 +19,17 @@
         </Grid.RowDefinitions>
         
         <StackPanel Grid.Row="0" Orientation="Horizontal">
+            <Button x:Name="PreviousGridButton" Content="Go to Previous Grid" Height="32" Width="140"
+    Click="PreviousGridButton_Click">
+            </Button>
+            <Label x:Name="GridLabel" Content="Grid Title" Height="32" Width="140" 
+                 FontSize="16" FontFamily="Calibri"  
+                 FontWeight="Bold"   
+                 Background="White"   
+                 Foreground="Black">
+            </Label>
             <Button x:Name="AdvanceGridButton" Content="Advance To Next Grid" Height="32" Width="140"
-                Click="AdvanceGridButton_Click">
+    Click="AdvanceGridButton_Click">
             </Button>
         </StackPanel>
 

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
@@ -12,30 +12,52 @@
         <local:SingleRenderDataValueConverter x:Key="SingleRenderDataValueConverter" />
     </UserControl.Resources>
     <Grid>
-        
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        
-        <StackPanel Grid.Row="0" Orientation="Horizontal">
-            <Button x:Name="PreviousGridButton" Content="Go to Previous Grid" Height="32" Width="140"
-    Click="PreviousGridButton_Click">
+        <StackPanel Grid.Column="0" 
+                    Grid.RowSpan="2"
+                    Orientation="Vertical" 
+                    HorizontalAlignment="Center"
+                    Background="#efefef">
+            <Button x:Name="PreviousGridButton" 
+                 Content="Go to Previous Grid" 
+                 Height="32" 
+                 Width="140"
+                 Click="PreviousGridButton_Click" 
+                 Margin="10,10,10,10">
             </Button>
-            <Label x:Name="GridLabel" Content="Grid Title" Height="32" Width="140" 
-                 FontSize="16" FontFamily="Calibri"  
+            <Button x:Name="AdvanceGridButton" 
+                 Content="Advance To Next Grid" 
+                 Height="32" 
+                 Width="140"
+                 Click="AdvanceGridButton_Click" 
+                 Margin="10,10,10,10">
+            </Button>
+        </StackPanel>
+        <Label x:Name="GridLabel" 
+                 Grid.Column="1" 
+                 Grid.Row="0" 
+                 Content="Grid Title" 
+                 Height="32" 
+                 Width="140" 
+                 FontSize="16" 
+                 FontFamily="Calibri"  
                  FontWeight="Bold"   
                  Background="White"   
                  Foreground="Black">
-            </Label>
-            <Button x:Name="AdvanceGridButton" Content="Advance To Next Grid" Height="32" Width="140"
-    Click="AdvanceGridButton_Click">
-            </Button>
-        </StackPanel>
-
-        <controls:Histogram2D x:Name="ProjectionGrid2dHistogram" Grid.Row="1" DataSource="{Binding SelectedGridRenderData, RelativeSource={RelativeSource AncestorType=local:ProjectionGridsView}}"
-             AxisXLabel="PCA dimension 1"
-             AxisYLabel="PCA dimension 0"/>
+        </Label>
+        <controls:Histogram2D x:Name="ProjectionGrid2dHistogram" 
+                Grid.Column="1" 
+                Grid.Row="1" 
+                DataSource="{Binding SelectedGridRenderData, RelativeSource={RelativeSource AncestorType=local:ProjectionGridsView}}"
+                AxisXLabel="PCA dimension"
+                AxisYLabel="PCA dimension"/>
 
     </Grid>
 </UserControl>

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
@@ -39,6 +39,17 @@
                  Click="AdvanceGridButton_Click" 
                  Margin="10,10,10,10">
             </Button>
+            <CheckBox x:Name="UseGridForPCAPhaseID" 
+                 Content="Use Grid for PCA Phase ID" 
+                 Height="32" 
+                 Width="140"
+                 Click="UseGridForPCAPhaseID_Click" 
+                 Margin="10,10,10,10">
+            </CheckBox>
+            <TextBlock x:Name="GridInfoText" 
+                 Width="140"
+                 Margin="10,10,10,10">
+            </TextBlock>
         </StackPanel>
         <Label x:Name="GridLabel" 
                  Grid.Column="1" 
@@ -53,7 +64,7 @@
                  Foreground="Black">
         </Label>
         <controls:Histogram2D x:Name="ProjectionGrid2dHistogram" 
-                Grid.Column="1" 
+                Grid.Column="2" 
                 Grid.Row="1" 
                 DataSource="{Binding SelectedGridRenderData, RelativeSource={RelativeSource AncestorType=local:ProjectionGridsView}}"
                 AxisXLabel="PCA dimension"

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -42,7 +42,6 @@ public partial class ProjectionGridsView : UserControl
         if (d is not ProjectionGridsView projectionGridsView) { return; }
         ICollection<IRenderData> renderData = projectionGridsView.GridsSource;
         int rdc = renderData.Count;
-        Debug.WriteLine("GridsSourcePropertyChanged called -- render data count is " + rdc);
     }
 
     private void GridsSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -71,16 +70,27 @@ public partial class ProjectionGridsView : UserControl
         return "PCA Component " + component;
     }
 
+    private string gridLetterFromIndex(int whichGrid)
+    {
+        int AAsciiValue = (int)'A';
+        char cha = (char)(AAsciiValue + whichGrid);
+        return cha.ToString();
+    }
     private void RefreshGridData()
     { 
         ICollection<IRenderData> renderDataCollection = this.GridsSource;
         int rdc = renderDataCollection.Count;
+ 
         if (rdc > 0)
         {
             List<IRenderData> renderList = renderDataCollection.ToList();
             if (whichGrid >= rdc)
             {
                 whichGrid = 0;
+            }
+            if (whichGrid < 0)
+            {
+                whichGrid = rdc - 1;
             }
 
             var renderData = renderList[whichGrid];
@@ -89,6 +99,10 @@ public partial class ProjectionGridsView : UserControl
             histogram.AxisXLabel = AxisXLabelForGridID(renderData.Name);
             histogram.AxisYLabel = AxisYLabelForGridID(renderData.Name);
             histogram.DataSource = singleList;
+            histogram.IsLegendVisible = true;
+            Label gridLabel = GridLabel;
+            String gridLetter = gridLetterFromIndex(whichGrid);
+            gridLabel.Content = "Grid Index " + whichGrid + " -- " + gridLetter;
         }
     }
 
@@ -128,6 +142,11 @@ public partial class ProjectionGridsView : UserControl
     private void AdvanceGridButton_Click(object sender, RoutedEventArgs e)
     {
         whichGrid += 1;
+        RefreshGridData();
+    }
+    private void PreviousGridButton_Click(object sender, RoutedEventArgs e)
+    {
+        whichGrid -= 1;
         RefreshGridData();
     }
 

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -70,12 +70,7 @@ public partial class ProjectionGridsView : UserControl
         return "PCA Component " + component;
     }
 
-    private string gridLetterFromIndex(int whichGrid)
-    {
-        int AAsciiValue = (int)'A';
-        char cha = (char)(AAsciiValue + whichGrid);
-        return cha.ToString();
-    }
+
     private void RefreshGridData()
     { 
         ICollection<IRenderData> renderDataCollection = this.GridsSource;
@@ -101,8 +96,9 @@ public partial class ProjectionGridsView : UserControl
             histogram.DataSource = singleList;
             histogram.IsLegendVisible = true;
             Label gridLabel = GridLabel;
-            String gridLetter = gridLetterFromIndex(whichGrid);
-            gridLabel.Content = "Grid Index " + whichGrid + " -- " + gridLetter;
+            gridLabel.Content = "Grid Index " + whichGrid;
+            // need to hook up to "grid label provider"
+            // so that we can associate the nth grid with a grid label
         }
     }
 

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -23,7 +23,8 @@ namespace Cameca.CustomAnalysis.Pca;
 /// </summary>
 public partial class ProjectionGridsView : UserControl
 {
-
+    string currentGridId = "";
+    HashSet<string> gridsToExcludeFromPCAPhaseID = new HashSet<string>();
     int whichGrid = 0;
     public ProjectionGridsView()
     {
@@ -36,6 +37,19 @@ public partial class ProjectionGridsView : UserControl
         typeof(ICollection<IRenderData>),
         typeof(ProjectionGridsView),
         new FrameworkPropertyMetadata(Array.Empty<IRenderData>(), GridsSourcePropertyChanged));
+
+    // GridsUsageProtocol is an object that can accept notifications of whether o not to use a particular grid as 
+    // part of the PCA Phase identification process.  So, when the "Use this grid in PCA Phase ID" button is clicked
+    // this object will get notified of the user intent.
+    public static readonly DependencyProperty GridsUsageDelegateProperty = DependencyProperty.Register(
+            nameof(GridsUsageDelegate),
+            typeof(IGridsUsageDelegate),
+            typeof(ProjectionGridsView),
+            new FrameworkPropertyMetadata(new DoNothingGridsUsageDelegate(), GridsUsageDelegatePropertyChanged));
+
+    private static void GridsUsageDelegatePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+    }
 
     private static void GridsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
@@ -82,6 +96,7 @@ public partial class ProjectionGridsView : UserControl
         if (rdc > 0)
         {
             List<IRenderData> renderList = renderDataCollection.ToList();
+
             if (whichGrid >= rdc)
             {
                 whichGrid = 0;
@@ -92,6 +107,7 @@ public partial class ProjectionGridsView : UserControl
             }
 
             var renderData = renderList[whichGrid];
+            currentGridId = renderData.Name;
             List<IRenderData> singleList = new List<IRenderData> { renderData };
             Histogram2D histogram = ProjectionGrid2dHistogram;
             //for whatever reason, for grid PQ, we seem to have put the P in the Y axis, and the Q in the Z axis
@@ -102,18 +118,28 @@ public partial class ProjectionGridsView : UserControl
             histogram.IsLegendVisible = true;
             Label gridLabel = GridLabel;
             gridLabel.Content = "Grid " + renderData.Name;
-            // need to hook up to "grid label provider"
-            // so that we can associate the nth grid with a grid label
+
+            UseGridForPCAPhaseID.IsChecked = GridsUsageDelegate.UsesGridForPca(currentGridId);
+        }
+    }
+
+    public IGridsUsageDelegate GridsUsageDelegate
+    {
+        get { return (IGridsUsageDelegate)GetValue(GridsUsageDelegateProperty); }
+        set
+        {
+            SetValue(GridsUsageDelegateProperty, value);
         }
     }
 
     public ICollection<IRenderData> GridsSource
     {
         get { return (ICollection<IRenderData>)GetValue(GridsSourceProperty); }
-        set { 
-                SetValue(GridsSourceProperty, value);
-                RefreshGridData();
-            }
+        set
+        {
+            SetValue(GridsSourceProperty, value);
+            RefreshGridData();
+        }
     }
 
     private void AdvanceGridButton_Click(object sender, RoutedEventArgs e)
@@ -126,7 +152,15 @@ public partial class ProjectionGridsView : UserControl
         whichGrid -= 1;
         RefreshGridData();
     }
+    private void UseGridForPCAPhaseID_Click(object sender, RoutedEventArgs e)
+    {
+        CheckBox checkBox = (CheckBox)sender;
+        bool? checkBoxChecked = checkBox.IsChecked;
+        bool isChecked = checkBoxChecked.HasValue ? checkBoxChecked.Value : true; 
+        GridsUsageDelegate.UseGridForPca(currentGridId, isChecked);
+    }
 
+    
     private static IEnumerable<T> GetChildren<T>(DependencyObject root) where T: DependencyObject
     {
         int childrenCount = VisualTreeHelper.GetChildrenCount(root);

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -106,33 +106,6 @@ public partial class ProjectionGridsView : UserControl
         }
     }
 
-    public void FillRenderDataWithGridData(IHistogram2DRenderData renderData, TwoDPeakProjection projection)
-    {
-       // renderData.ColorMap = Resources.ColorMap.GetPresetColorMap(ColorMapPreset.GreyScale);
-        DensityPlane dp = projection.densityPlane;
-        (TwoDGridCoord minCoord, TwoDGridCoord maxCoord) = dp.MinMaxGridCoords();
-        int spanX = 1 + maxCoord.x - minCoord.x;
-        int spanY = 1 + maxCoord.y - minCoord.y;
-        int span = Math.Max(spanX, spanY);
-        int numCoords = span * span;
-        float[] dat = new float[numCoords * 4];
-        for (int q = 0; q < spanY; q += 1)
-        {
-            int qOffset = q * span;
-            int gridq = q + minCoord.y;
-            for (int p = 0; p < spanX; p += 1)
-            {
-                int arrayIndex = qOffset + p;
-                int gridp = p + minCoord.x;
-                dat[arrayIndex] = dp.valueAtGridCoords(gridp, gridq);
-            }
-        }
-        ReadOnlyMemory2D<float> rom = new ReadOnlyMemory2D<float>(dat, span, span);
-        Vector2 binsize = new Vector2(0.5f, 0.5f); // Vector2(dp.binsize, dp.binsize);
-        Vector2 origin = new Vector2(minCoord.x * dp.binsize, minCoord.y * dp.binsize);
-        renderData.Update(rom, binsize, origin);
-    }
-
     public ICollection<IRenderData> GridsSource
     {
         get { return (ICollection<IRenderData>)GetValue(GridsSourceProperty); }

--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml.cs
@@ -41,7 +41,7 @@ public partial class ProjectionGridsView : UserControl
     {
         if (d is not ProjectionGridsView projectionGridsView) { return; }
         ICollection<IRenderData> renderData = projectionGridsView.GridsSource;
-        int rdc = renderData.Count;
+        projectionGridsView.RefreshGridData();
     }
 
     private void GridsSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -49,25 +49,28 @@ public partial class ProjectionGridsView : UserControl
         RefreshGridData();
     }
 
+    internal string AxisLabelForGridLetter(char gridLetter)
+    { 
+        return "PCA Component " + TwoDGridID.IndexForGridLetter(gridLetter);
+    }
+
     internal string AxisYLabelForGridID(string gridID)
     {
-        string[] components = gridID.Split("-");
-        if (components.Count() != 2)
+        if (gridID.Count() != 2)
         {
             return "Unknown Pca Axis";
         }
-        string component = components[0];
-        return "PCA Component " + component.Substring(1);
+        return AxisLabelForGridLetter(gridID[0]);
     }
+
+    // 
     internal string AxisXLabelForGridID(string gridID)
     {
-        string[] components = gridID.Split("-");
-        if (components.Count() != 2)
+        if ( gridID.Count() != 2 )
         {
             return "Unknown Pca Axis";
         }
-        string component = components[1];
-        return "PCA Component " + component;
+        return AxisLabelForGridLetter(gridID[1]);
     }
 
 
@@ -91,12 +94,14 @@ public partial class ProjectionGridsView : UserControl
             var renderData = renderList[whichGrid];
             List<IRenderData> singleList = new List<IRenderData> { renderData };
             Histogram2D histogram = ProjectionGrid2dHistogram;
+            //for whatever reason, for grid PQ, we seem to have put the P in the Y axis, and the Q in the Z axis
+            // so, the X axis gets its name from the second letter in the grid ID
             histogram.AxisXLabel = AxisXLabelForGridID(renderData.Name);
             histogram.AxisYLabel = AxisYLabelForGridID(renderData.Name);
             histogram.DataSource = singleList;
             histogram.IsLegendVisible = true;
             Label gridLabel = GridLabel;
-            gridLabel.Content = "Grid Index " + whichGrid;
+            gridLabel.Content = "Grid " + renderData.Name;
             // need to hook up to "grid label provider"
             // so that we can associate the nth grid with a grid label
         }
@@ -105,7 +110,10 @@ public partial class ProjectionGridsView : UserControl
     public ICollection<IRenderData> GridsSource
     {
         get { return (ICollection<IRenderData>)GetValue(GridsSourceProperty); }
-        set { SetValue(GridsSourceProperty, value); }
+        set { 
+                SetValue(GridsSourceProperty, value);
+                RefreshGridData();
+            }
     }
 
     private void AdvanceGridButton_Click(object sender, RoutedEventArgs e)

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -9,20 +9,27 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.Arm;
 using System.Windows.Controls;
 using System.Text.RegularExpressions;
+using System.Security.Cryptography.X509Certificates;
 
 public struct PixelID : IComparable<PixelID>
 {
     public int pixelId;
+    static int maxgrid = 510;
 
     public PixelID(int pixelId)
     {
         this.pixelId = pixelId;
     }
 
-    public PixelID(int x, int y)
+    public static PixelID? PixelIDFor(int x, int y)
     {
-        pixelId = y * 1024 + x;
+        if ((x > maxgrid) || (x < -maxgrid) || (y > maxgrid) || (y < -maxgrid))
+        {
+            return null;
+        }
+        return new PixelID(y * 1024 + x);
     }
+
     public (int, int) xyCoords()
     {
         int y = (512 + pixelId) >> 10;
@@ -34,6 +41,7 @@ public struct PixelID : IComparable<PixelID>
     {
         return other.pixelId > pixelId ? -1 : other.pixelId < pixelId ? 1 : 0;
     }
+
     public string DebugStr()
     {
         int x;
@@ -105,18 +113,71 @@ public class DensityPlane
         data = new Dictionary<PixelID, float>();
         maxval = 1022.0f * binSep;
     }
-    
+
+    public delegate void ForEachPixelCallback(PixelID pixelId, float value);
+
+    public void ForEachPixel(ForEachPixelCallback callback)
+    {
+        foreach (KeyValuePair<PixelID, float> kvp in data)
+        {
+            callback(kvp.Key, kvp.Value);
+        }
+    }
+
+    public DensityPlane Convolve(List<float> normalizedCoefficients)
+    {
+        DensityPlane newDP = new DensityPlane(this.binsize);
+        if (normalizedCoefficients.Count > 0)
+        {
+            int maxx = normalizedCoefficients.Count - 1;
+            int minx = -maxx;
+            int maxy = maxx;
+            int miny = minx;
+            void convolutionFunction(PixelID pixelId, float value)
+            {
+                (int p, int q) = pixelId.xyCoords();
+                for (int x = minx; x <= maxx; x+=1)
+                {
+                    int xCoefficientIndex = (int)Math.Abs(x);
+                    float xCoeff = normalizedCoefficients[xCoefficientIndex];
+                    for (int y = miny; y <= maxy; y += 1)
+                    {
+                        int yCoefficientIndex = (int)Math.Abs(y);
+                        float yCoeff = normalizedCoefficients[yCoefficientIndex];
+                        PixelID? nthPixelID = PixelID.PixelIDFor(p + x, q + y);
+                        if (nthPixelID != null)
+                        {  
+                            newDP.AddValueAtPixel(nthPixelID.Value, value * xCoeff * yCoeff);
+                        }
+                    }
+                }
+            }
+            ForEachPixel(convolutionFunction);
+        }
+        return newDP;
+    }
+
+    public void AddValueAtPixel(PixelID pixelId, float value)
+    {
+        data[pixelId] = valueAtPixel(pixelId) + value;
+    }
+
     public List<PixelID> GridPointIds()
     {
         return data.Keys.ToList();
     }
 
-    internal void AddIfPossible(int x, int y, List<PixelID> list)
+    internal void AddIfNonZero(int x, int y, List<PixelID> list)
     {
-        PixelID possibleBin = new PixelID(x, y);
-        if (data.ContainsKey(possibleBin))
+        PixelID? possibleBin = PixelID.PixelIDFor(x, y);
+        if (possibleBin != null)
         {
-            list.Add(possibleBin);
+            PixelID pixelId = possibleBin.Value;
+            if (data.ContainsKey(pixelId))
+            {
+                list.Add(pixelId);
+            }
+              
         }
     }
 
@@ -127,14 +188,14 @@ public class DensityPlane
         //int y;
         (int x, int y) = pixelId.xyCoords();
         List<PixelID> neighbors = new List<PixelID>();
-        AddIfPossible(x - 1, y - 1, neighbors);
-        AddIfPossible(x - 1, y, neighbors);
-        AddIfPossible(x - 1, y + 1, neighbors);
-        AddIfPossible(x, y-1, neighbors);
-        AddIfPossible(x, y+1, neighbors);
-        AddIfPossible(x + 1, y-1, neighbors);
-        AddIfPossible(x + 1, y, neighbors);
-        AddIfPossible(x + 1, y + 1, neighbors);
+        AddIfNonZero(x - 1, y - 1, neighbors);
+        AddIfNonZero(x - 1, y, neighbors);
+        AddIfNonZero(x - 1, y + 1, neighbors);
+        AddIfNonZero(x, y-1, neighbors);
+        AddIfNonZero(x, y+1, neighbors);
+        AddIfNonZero(x + 1, y-1, neighbors);
+        AddIfNonZero(x + 1, y, neighbors);
+        AddIfNonZero(x + 1, y + 1, neighbors);
 
 		return neighbors;
 	}
@@ -229,16 +290,21 @@ public class DensityPlane
 			string l = "{";
 			for (int x = min.x; x <= max.x; ++x)
 			{
-				PixelID xthKey = new PixelID(x, y);
-				float xthValue = 0;
-				if (data.ContainsKey(xthKey))
-				{
-					xthValue = data[xthKey];
-				}
-				l = l + xthValue;
-				if (x != max.x) {
-					l = l + ",";
-				}  
+				PixelID? xthKey = PixelID.PixelIDFor(x, y);
+                if (xthKey != null)
+                {
+                    PixelID xthPixelId = xthKey.Value;
+                    float xthValue = 0;
+                    if (data.ContainsKey(xthPixelId))
+                    {
+                        xthValue = data[xthPixelId];
+                    }
+                    l = l + xthValue;
+                    if (x != max.x)
+                    {
+                        l = l + ",";
+                    }
+                }
 			}
 			l = l + "}";
 			stream.Write(l);
@@ -323,12 +389,12 @@ public class DensityPlane
         return (xBinIndex, yBinIndex);
     }
 
-    public PixelID PixelIDFor(float x, float y)
+    public PixelID? PixelIDFor(float x, float y)
     {
         int binx;
         int biny;
         (binx, biny) = PixelIndicesFor(x, y);
-        return new PixelID(binx, biny);
+        return PixelID.PixelIDFor(binx, biny);
     }
 
     public void AddPointAt(float x, float y)
@@ -353,6 +419,15 @@ public class DensityPlane
             return (.5f * MathF.Pow(x + 0.5f, 2));
         }
 
+        void addValueAtCoords(int x, int y, float val)
+        {
+            PixelID? pixelId = PixelID.PixelIDFor(x, y);
+            if (pixelId != null)
+            {
+                AddValueAtPixel(pixelId.Value, val);
+            }
+        }
+
         int xBinIndex;
         int yBinIndex;
         (xBinIndex, yBinIndex) = PixelIndicesFor(x, y);
@@ -367,26 +442,15 @@ public class DensityPlane
         float yp1 = (float)Pos1Func(yRem);    // these are the spline transfer functions
         float y0 = (float)ZeroFunc(yRem);
 
-        PixelID bin = new PixelID(xBinIndex - 1, yBinIndex - 1);
-        data[bin] = valueAtPixel(bin) + xm1 * ym1;
-        bin = new PixelID(xBinIndex, yBinIndex - 1);
-        data[bin] = valueAtPixel(bin) + x0 * ym1;
-        bin = new PixelID(xBinIndex + 1, yBinIndex - 1);
-        data[bin] = valueAtPixel(bin) + xp1 * ym1;
-
-        bin = new PixelID(xBinIndex - 1, yBinIndex);
-        data[bin] = valueAtPixel(bin) + xm1 * y0;
-        bin = new PixelID(xBinIndex, yBinIndex);
-        data[bin] = valueAtPixel(bin) + x0 * y0;
-        bin = new PixelID(xBinIndex + 1, yBinIndex);
-        data[bin] = valueAtPixel(bin) + xp1 * y0;
-
-        bin = new PixelID(xBinIndex - 1, yBinIndex + 1);
-        data[bin] = valueAtPixel(bin) + xm1 * yp1;
-        bin = new PixelID(xBinIndex, yBinIndex + 1);
-        data[bin] = valueAtPixel(bin) + x0 * yp1;
-        bin = new PixelID(xBinIndex + 1, yBinIndex + 1);
-        data[bin] = valueAtPixel(bin) + xp1 * yp1;
+        addValueAtCoords(xBinIndex - 1, yBinIndex - 1, xm1 * ym1);
+        addValueAtCoords(xBinIndex, yBinIndex - 1, x0 * ym1);
+        addValueAtCoords(xBinIndex + 1, yBinIndex - 1, xp1 * ym1);
+        addValueAtCoords(xBinIndex - 1, yBinIndex, xm1 * y0);
+        addValueAtCoords(xBinIndex, yBinIndex, x0 * y0);
+        addValueAtCoords(xBinIndex + 1, yBinIndex, xp1 * y0);
+        addValueAtCoords(xBinIndex - 1, yBinIndex + 1, xm1 * yp1);
+        addValueAtCoords(xBinIndex, yBinIndex + 1, x0 * yp1);
+        addValueAtCoords(xBinIndex + 1, yBinIndex + 1, xp1 * yp1);
 
     }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -16,6 +16,7 @@ using System.Runtime.Intrinsics.Arm;
 using System.Net.Http;
 using System.Data.SqlTypes;
 using System.Reflection;
+using System.Windows;
 
 
 // PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
@@ -35,6 +36,11 @@ public class PcaScoresGrid
     Dictionary<VoxelID, PcaVoxel> pcaVoxels; // the key is the 'id' for the voxel, from which you can
                                              // calculate the x,y,z position of the voxel on the grid if
                                              // the grid dimensions are known
+
+    Dictionary<TwoDGridID, List<List<PixelID>>> partitions; // key is grid ID
+          // value is lists of associations of voxelID with different peaks
+
+    Dictionary<TwoDGridID, DensityPlane> twoDGrids;  // key is grid ID
 
     int scoreDims;
     ThreeDGridDimensions gridDims;
@@ -92,6 +98,8 @@ public class PcaScoresGrid
         pcaVoxels = pcaVoxelsInit(scoresProvider, nIndices);
 
         gridDims = gridDimensions;
+        partitions = new Dictionary<TwoDGridID, List<List<PixelID>>>();
+        twoDGrids = new Dictionary<TwoDGridID, DensityPlane>();
     }
 
     static Dictionary<VoxelID, PcaVoxel> pcaVoxelsInit(IScoresProvider scoresProvider, int nIndices)
@@ -354,6 +362,7 @@ public class PcaScoresGrid
         }
     }
 
+
     // GetPhasesStrategyE is produces PhaseIdResults based on the first three 
     // PCA dimensions only  
     //
@@ -375,38 +384,25 @@ public class PcaScoresGrid
     // D) add voxels that abut any of the contiguous regions to those regions iff
     //    the code they have matches all code snippet for which they have a non-zero number
     //    i.e. A0B1C1  is a match for contiguous regions A1B1C1 and A2B1C1
-    public PhaseIdResults GetPhasesStrategyE(PcaPhaseIdentificationProperties properties)
+    public TwoDGridsResults CalculateTwoDGrids(PcaPhaseIdentificationProperties properties)
     {
-        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
+        TwoDGridsResults gridsResults = new TwoDGridsResults();
+        twoDGrids.Clear();
+        partitions.Clear();
 
-        // PcaStream writes a file with text data about the progression of the algorithm
-        // uncomment it here and uncomment the calls to DumpVoxelSetStats below
-        //  PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
-        // pcaStream.WriteTimestamp("start GetPhasesStrategyE");
-        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
+        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
 
         float binSeparation = properties.gridProjectionBinSize;
         float delocalization = properties.gridProjectionDelocalization;
-        int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims);
-        Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
-        Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
-
-        // make a dictionary for the pcaCodes and fill with empty Strings
-        Dictionary<VoxelID, PcaPhaseName> pcaCodes = new Dictionary<VoxelID, PcaPhaseName>();
-        foreach (VoxelID voxelId in voxelIds)
-        {
-            pcaCodes[voxelId] = new PcaPhaseName();
-        }
-
+        int numDimsToInclude = this.scoreDims;
+ 
         int AAsciiValue = ASCIIValueForChar('A');
-        int gridIndex = 0;
         // now, make twoD grids using all pairs of dimensions
         for (int i = 0; i < (numDimsToInclude - 1); ++i)
         {
             for (int j = i + 1; j < numDimsToInclude; ++j)
             {
-                string gridLetter = CharValueForASCII(AAsciiValue + gridIndex).ToString();
-                string gridId = gridLetter + i.ToString() + "-" + j.ToString();
+                TwoDGridID gridId = new TwoDGridID(i, j);
 
                 // this makes the 2D grid  --  step A) above
                 var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation, delocalization);
@@ -416,53 +412,85 @@ public class PcaScoresGrid
                 List<List<PixelID>> partitionedIndices = IdentifyPartitions(twoDGrid, i, j, properties);
                 partitions[gridId] = partitionedIndices;
 
+                var projection = new TwoDPeakProjection(twoDGrid);
+                gridsResults.SetTwoDPeakProjectionFor(gridId, projection);
+                partitions[gridId] = partitionedIndices;
+
                 // Enable this to get a text file with partition data
-                // DumpPartitions(partitionedIndices, gridId);
+                // DumpPartitions(partitionedIndices, gridId);     
+            }
+        }
+        return gridsResults;
+    }
+    public PhaseIdResults GetPhasesStrategyE(PcaPhaseIdentificationProperties properties)
+    {
+        List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
+        int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims);
 
-                // now label each voxel with a PCA code based on its peak association
-                // for each grid, group the voxels into lists per pixel, then, knowing
-                // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
-                // the PCA code dictionary
-                int peakIndex = 1;
-                Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, i, j);
-                foreach (List<PixelID> pixelIdList in partitionedIndices)
-                {
-                    string pcaCode = gridLetter + "." + peakIndex.ToString();
-                    // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
-                    foreach (PixelID pixelID in pixelIdList)
-                    {
-                        // Lookup for all the voxels bucketed under this pixelId
-                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
-                        {
-                            pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
-                        }
-                        // remove that entry from voxelLists
-                        voxelLists.Remove(pixelID);
-                    }
-                    peakIndex += 1;
-                }
+        // make a dictionary for the pcaCodes and fill with empty Strings
+        Dictionary<VoxelID, PcaPhaseName> pcaCodes = new Dictionary<VoxelID, PcaPhaseName>();
+        foreach (VoxelID voxelId in voxelIds)
+        {
+            pcaCodes[voxelId] = new PcaPhaseName();
+        }
+        // starting here, loop through the grids and if we have selected 
+        // the grid to be used in PCA phase Identification,
+        // get the grid ID and assign pca codes to all the voxels based on 
+        // which peak it is part of in the grid
 
-                // now, all the remaining entries in voxelLists are unassigned :  
-                // assign these to component 0
-                string unassignedPcaCode = gridLetter + ".0";
-                List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
-                foreach (PixelID pixelID in unassignedPixels)
+        // TODO start loop
+        foreach (KeyValuePair<TwoDGridID, List<List<PixelID>>> kvp in partitions)
+        {
+            // now label each voxel with a PCA code based on its peak association
+            // for each grid, group the voxels into lists per pixel, then, knowing
+            // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
+            // the PCA code dictionary
+            TwoDGridID gridID = kvp.Key;
+            DensityPlane twoDGrid = twoDGrids[gridID];
+            List<List<PixelID>> partitionedIndices = kvp.Value;
+            (int firstDim, int secondDim) = gridID.AsIndexPair();
+
+            Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, firstDim, secondDim);
+            int peakIndex = 1;
+
+            foreach (List<PixelID> pixelIdList in partitionedIndices)
+            {
+                string pcaCode = gridID + "." + peakIndex.ToString();
+                // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
+                foreach (PixelID pixelID in pixelIdList)
                 {
                     // Lookup for all the voxels bucketed under this pixelId
                     List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
                     foreach (VoxelID voxelId in voxelIdsForThisPixel)
                     {
-                        pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(unassignedPcaCode);
+                        pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
                     }
+                    // remove that entry from voxelLists
+                    voxelLists.Remove(pixelID);
                 }
+                peakIndex += 1;
+            }
 
-                var projection = new TwoDPeakProjection(twoDGrid);
-                phaseIdResults.SetTwoDPeakProjectionFor(gridId, projection);
-
-                gridIndex += 1;
+            // now, all the remaining entries in voxelLists are unassigned :  
+            // assign these to component 0
+            string unassignedPcaCode = gridID + ".0";
+            List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
+            foreach (PixelID pixelID in unassignedPixels)
+            {
+                // Lookup for all the voxels bucketed under this pixelId
+                List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                {
+                    pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(unassignedPcaCode);
+                }
             }
         }
+
+        // PcaStream writes a file with text data about the progression of the algorithm
+        // uncomment it here and uncomment the calls to DumpVoxelSetStats below
+        //  PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+        // pcaStream.WriteTimestamp("start GetPhasesStrategyE");
+        PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
         // pcaStream.WriteTimestamp("finished making grids");
         // now examine the groups of voxels to identify contiguous regions

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -341,25 +341,40 @@ public class PcaScoresGrid
             sets[kvp.Key] = hashSet;
         }
     }
-    void subtractVoxelsFromHashSetDictionary(Dictionary<PcaPhaseName, HashSet<VoxelID>> subtractions, Dictionary<PcaPhaseName, HashSet<VoxelID>> sets)
+
+    // return the total number of voxels unassigned
+    int subtractVoxelsFromHashSetDictionary(Dictionary<PcaPhaseName, HashSet<VoxelID>> subtractions, Dictionary<PcaPhaseName, HashSet<VoxelID>> sets)
     {
+        int unassignedCount = 0;
         foreach (KeyValuePair<PcaPhaseName, HashSet<VoxelID>> kvp in subtractions)
         {
-            HashSet<VoxelID> hashSet;
+ 
             if (sets.ContainsKey(kvp.Key))
             {
-                hashSet = sets[kvp.Key];
+
+                HashSet<VoxelID> hashSet = sets[kvp.Key];
+                int countBeforeRemoval = hashSet.Count;
+
+                foreach (VoxelID voxelId in kvp.Value)
+                {
+                    hashSet.Remove(voxelId);
+                }
+                int subtractionsCount = kvp.Value.Count;
+                int countAfterRemoval = hashSet.Count;
+                int actuallyRemoved = countBeforeRemoval - countAfterRemoval;
+                if (actuallyRemoved != subtractionsCount)
+                {
+                    throw new Exception("subtractVoxels expected all voxels to exist in previous bucket");
+                }
+                unassignedCount += actuallyRemoved;
+                sets[kvp.Key] = hashSet;
             }
             else
             {
-                hashSet = new HashSet<VoxelID>();
+                throw new Exception("subtractVoxels expected existing bucket of voxels");
             }
-            foreach (VoxelID voxelId in kvp.Value)
-            {
-                hashSet.Remove(voxelId);
-            }
-            sets[kvp.Key] = hashSet;
         }
+        return unassignedCount;
     }
 
 
@@ -417,7 +432,7 @@ public class PcaScoresGrid
                 partitions[gridId] = partitionedIndices;
 
                 // Enable this to get a text file with partition data
-                // DumpPartitions(partitionedIndices, gridId);     
+                // DumpPartitions(partitionedIndices, gridId.ToString());     
             }
         }
         return gridsResults;
@@ -473,7 +488,7 @@ public class PcaScoresGrid
 
             // now, all the remaining entries in voxelLists are unassigned :  
             // assign these to component 0
-            string unassignedPcaCode = gridID + ".0";
+            string unassignedPcaCode = gridID.ToString() + ".0";
             List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
             foreach (PixelID pixelID in unassignedPixels)
             {
@@ -488,11 +503,9 @@ public class PcaScoresGrid
 
         // PcaStream writes a file with text data about the progression of the algorithm
         // uncomment it here and uncomment the calls to DumpVoxelSetStats below
-        //  PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
-        // pcaStream.WriteTimestamp("start GetPhasesStrategyE");
+        PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
         PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
-        // pcaStream.WriteTimestamp("finished making grids");
         // now examine the groups of voxels to identify contiguous regions
         // in this case, 'unassigned' means voxels not yet associated with a list of voxels in a pcaPhase
         Dictionary<PcaPhaseName, HashSet<VoxelID>> unassignedVoxelBuckets = VoxelBuckets(pcaCodes);
@@ -534,10 +547,9 @@ public class PcaScoresGrid
         // for case 2) add the voxels to the core regions
         // for case 3) designate the voxel as an interface voxel
 
-        int voxelAssignmentIterationCount = 10;
-        for (int voxelAssignmentIteration = 0; voxelAssignmentIteration < voxelAssignmentIterationCount; voxelAssignmentIteration += 1)
+        int voxelAssignmentCount = 1;
+        while (voxelAssignmentCount > 0)
         {
-            // pcaStream.WriteTimestamp("start voxel assignment loop # " + voxelAssignmentIteration);
             Dictionary<PcaPhaseName, HashSet<VoxelID>> unassignedSubtractions = new Dictionary<PcaPhaseName, HashSet<VoxelID>>();
             Dictionary<PcaPhaseName, HashSet<VoxelID>> voxelSetAdditions = new Dictionary<PcaPhaseName, HashSet<VoxelID>>();
             Dictionary<PcaPhaseNameList, HashSet<VoxelID>> interfaceVoxelSetAdditions = new Dictionary<PcaPhaseNameList, HashSet<VoxelID>>();
@@ -606,7 +618,7 @@ public class PcaScoresGrid
             // calls to DumpVoxelSetStats are used to follow the progression of the algorithm is assigning voxels
             // these can be enabled if the pcaStream object is created above
 
-            // pcaStream.WriteTimestamp("finished voxel partitioning" );
+            pcaStream.WriteTimestamp("finished voxel partitioning" );
             // pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets); 
             // pcaStream.DumpVoxelSetStats("start pcaCodeVoxelSets", pcaCodeVoxelSets);
             // pcaStream.DumpVoxelSetStats("startUnassigned", unassignedVoxelBuckets);
@@ -615,12 +627,12 @@ public class PcaScoresGrid
 
             addVoxelsToPcaPhaseNameListSet(interfaceVoxelSetAdditions, interfaceVoxelSets);
             addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
-            subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
+            voxelAssignmentCount = subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
 
             // pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
             //  pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
             //  pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
-            //  pcaStream.WriteTimestamp("finished voxel loop");
+            pcaStream.WriteTimestamp("assigned " + voxelAssignmentCount + " voxels");
         }
 
         // now, pcaCodeVoxelSets is ready to be used for define a per-voxel component mapping
@@ -678,7 +690,7 @@ public class PcaScoresGrid
             }
         }
 
-        // pcaStream.Close();
+        pcaStream.Close();
         return phaseIdResults;
     }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -13,6 +13,9 @@ using System.Windows.Media.Animation;
 using System.Reflection.PortableExecutable;
 using Cameca.CustomAnalysis.Pca;
 using System.Runtime.Intrinsics.Arm;
+using System.Net.Http;
+using System.Data.SqlTypes;
+using System.Reflection;
 
 
 // PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
@@ -121,17 +124,21 @@ public class PcaScoresGrid
         foreach (VoxelID voxelId in voxelIds)
         {
             PcaVoxel voxel = pcaVoxels[voxelId];
-            PixelID nthPixelId = grid.PixelIDFor(voxel.scoreVector[firstDim], voxel.scoreVector[secondDim]);
-            List<VoxelID>? voxelIDListForGridCoord;
-            if (voxelLists.TryGetValue(nthPixelId, out voxelIDListForGridCoord))
+            PixelID? nthPixelId = grid.PixelIDFor(voxel.scoreVector[firstDim], voxel.scoreVector[secondDim]);
+            if (nthPixelId != null)
             {
-                voxelIDListForGridCoord.Add(voxelId);
-            }
-            else
-            {
-                voxelIDListForGridCoord = new List<VoxelID>();
-                voxelIDListForGridCoord.Add(voxelId);
-                voxelLists[nthPixelId] = voxelIDListForGridCoord;
+                PixelID pixelID = nthPixelId.Value;
+                List<VoxelID>? voxelIDListForGridCoord;
+                if (voxelLists.TryGetValue(pixelID, out voxelIDListForGridCoord))
+                {
+                    voxelIDListForGridCoord.Add(voxelId);
+                }
+                else
+                {
+                    voxelIDListForGridCoord = new List<VoxelID>();
+                    voxelIDListForGridCoord.Add(voxelId);
+                    voxelLists[pixelID] = voxelIDListForGridCoord;
+                }
             }
         }
         return voxelLists;
@@ -267,7 +274,7 @@ public class PcaScoresGrid
                         matchesAll = false;
                     }
                 }
-                
+
                 // the last token might be an emptyString
                 string lastToken = tokens[lastTokenIndex];
                 if ((lastToken.Length > 0) && (!candidate.Contains(lastToken)))
@@ -346,7 +353,7 @@ public class PcaScoresGrid
             sets[kvp.Key] = hashSet;
         }
     }
-    
+
     // GetPhasesStrategyE is produces PhaseIdResults based on the first three 
     // PCA dimensions only  
     //
@@ -374,16 +381,17 @@ public class PcaScoresGrid
 
         // PcaStream writes a file with text data about the progression of the algorithm
         // uncomment it here and uncomment the calls to DumpVoxelSetStats below
-       //  PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
+        //  PcaStream pcaStream = new PcaStream("GetPhasesStrategyE");
         // pcaStream.WriteTimestamp("start GetPhasesStrategyE");
         PhaseIdResults phaseIdResults = new PhaseIdResults(voxelIds);
 
-        float binSeparation = 0.5f;
-        int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims); 
+        float binSeparation = properties.gridProjectionBinSize;
+        float delocalization = properties.gridProjectionDelocalization;
+        int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims);
         Dictionary<string, DensityPlane> twoDGrids = new Dictionary<string, DensityPlane>();
         Dictionary<string, List<List<PixelID>>> partitions = new Dictionary<string, List<List<PixelID>>>();
 
-        // make a dictionary for the pcaCodes and fill with enpty Strings
+        // make a dictionary for the pcaCodes and fill with empty Strings
         Dictionary<VoxelID, PcaPhaseName> pcaCodes = new Dictionary<VoxelID, PcaPhaseName>();
         foreach (VoxelID voxelId in voxelIds)
         {
@@ -401,7 +409,7 @@ public class PcaScoresGrid
                 string gridId = gridLetter + i.ToString() + "-" + j.ToString();
 
                 // this makes the 2D grid  --  step A) above
-                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation);
+                var twoDGrid = CalculateTwoDDensity(voxelIds, i, j, binSeparation, delocalization);
                 twoDGrids[gridId] = twoDGrid;
 
                 // this identifies the peaks --  step B) above
@@ -481,7 +489,7 @@ public class PcaScoresGrid
         {
             // just copy over the voxel List to be the base list for  that phase
             pcaCodeVoxelSets[pcaCode] = unassignedVoxelBuckets[pcaCode];
-            unassignedVoxelBuckets.Remove(pcaCode); 
+            unassignedVoxelBuckets.Remove(pcaCode);
         }
 
         // now pcaCodeVoxelSets is filled with data for each pcaCode,
@@ -581,10 +589,10 @@ public class PcaScoresGrid
             addVoxelsToHashSetDictionary(voxelSetAdditions, pcaCodeVoxelSets);
             subtractVoxelsFromHashSetDictionary(unassignedSubtractions, unassignedVoxelBuckets);
 
-           // pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
-           //  pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
-           //  pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
-           //  pcaStream.WriteTimestamp("finished voxel loop");
+            // pcaStream.DumpVoxelSetStats("assignments sources", unassignedSubtractions);
+            //  pcaStream.DumpVoxelSetStats("new pcaCodeVoxelSets", pcaCodeVoxelSets);
+            //  pcaStream.DumpVoxelSetStats("stillUnassigned", unassignedVoxelBuckets);
+            //  pcaStream.WriteTimestamp("finished voxel loop");
         }
 
         // now, pcaCodeVoxelSets is ready to be used for define a per-voxel component mapping
@@ -601,7 +609,7 @@ public class PcaScoresGrid
         PcaPhaseName interfaceVoxelsPhaseName = PcaPhaseName.InterfaceVoxelsPhaseName();
         phaseIndexMap[unassignedVoxelsPhaseName] = 0;
         int phaseIndex = 1;
-        foreach (PcaPhaseName pcaCode in  pcaCodesByPopulation)
+        foreach (PcaPhaseName pcaCode in pcaCodesByPopulation)
         {
             phaseIndexMap[pcaCode] = phaseIndex;
             phaseIndex += 1;
@@ -674,8 +682,99 @@ public class PcaScoresGrid
         partitionFinder.Clear();
         return pixelLists;
     }
+    private double gaussianOfXWithInverseG(float x, float inverseg)
+    {
+        double dx = (double)x;
+        double dig = (double)inverseg;
+        return (dig * Math.Exp(-Math.PI * x * x * dig * dig));
+    }
 
-    public DensityPlane CalculateTwoDDensity(List<VoxelID> voxelIds, int dimx, int dimy, float binsize)
+
+    // The coefficients for positive values (i.e. all but the first one at index zero)
+    // are also used for the negative values, and the area under the curve should be equal to one.
+    // so, add up all the values and adjust them all so that the total is one.
+    private List<float> normalizeCoefficients(List<double> coeffs)
+    {
+        int limit = coeffs.Count - 1;
+        List<float> normalized = new List<float>();
+        if (limit >= 0)
+        {
+            double sum = 0.0;
+            for (int h = -limit; h <= limit; ++h)
+            {
+                int indexInArray = (h < 0) ? -h : h;
+                sum += coeffs[indexInArray];
+            }
+            double correction = (1.0 / sum);
+            for (int h = 0; h <= limit; ++h)
+            {
+                normalized.Add((float)(coeffs[h] * correction));
+            }
+        }
+        return normalized;
+    }
+
+    // In the case of a small extra delocalization, a gaussian doesn't capture
+    // enough delocalization, because there are not enough buckets in the main part of the curve
+    // In this case, boost the coefficients at -1 and 1 to produce the expected delocalization
+    List<float> adjustCoefficientsForDeloc(List<float> coefficients, float targetDelocalization, float binsize)
+    {
+        int maxIndex = coefficients.Count - 1;
+        if (maxIndex > 0)
+        {
+            float delocSum = 0.0f;
+            float nonZeroCoeffSum = 0.0f;
+            for (int index = 1; index <= maxIndex; index += 1)
+            {
+                // the delocalization is the distance squared times the coefficient
+                // and counted twice, once for negative, once for positive
+                float distance = index * binsize;
+                delocSum += 2 * distance * distance * coefficients[index];
+                nonZeroCoeffSum += 2 * coefficients[index];
+            }
+
+            // the meaning of these sums:
+            // nonZeroCoeffSum is the fraction between 0 and 1 of the
+            // origin bucket redistributed to other buckets
+            // delocSum is the amount of delocalization resulting from that distribution
+            if (maxIndex > 1)
+            {
+                // to get the target delocalization, multiply each non-zeroBucket
+                // by targetDelocalization / delocSum  and subtract the net change from
+                // the origin bucket
+                float boostFactor = (targetDelocalization / delocSum) - 1.0f;
+                float transferredSum = 0.0f;
+                // extra deloc should be less than coeff[0]
+                for (int index = 1; index <= maxIndex; index += 1)
+                {
+                    float nthBoost = boostFactor * coefficients[index];
+                    coefficients[index] += nthBoost;
+                    transferredSum += nthBoost;
+                }
+
+                // 
+                coefficients[0] -= 2 * transferredSum;
+
+            }
+            else if (maxIndex == 1)
+            {
+                // to achieve the extra deloc, calculate how much of coeff[0] we need to
+                // move to coeff[1] value to compensate
+                float extraDelocNeeded = targetDelocalization - delocSum;
+                float amountToTransfer = extraDelocNeeded / (binsize * binsize);
+                coefficients[0] -= amountToTransfer;
+                coefficients[1] += amountToTransfer * 0.5f;
+            }
+            if (coefficients[0] < 0.0f)
+            {
+                // something has gone very wrong
+                throw new Exception("adjustCoefficientsForDeloc value out of bounds");
+            }
+        }
+        return coefficients;
+    }
+
+    public DensityPlane CalculateTwoDDensity(List<VoxelID> voxelIds, int dimx, int dimy, float binsize, float delocalizationDistance)
     {
         DensityPlane densityPlane = new DensityPlane(binsize);
         for (int v = 0; v < voxelIds.Count; ++v)
@@ -686,25 +785,58 @@ public class PcaScoresGrid
             var yVal = voxel.scoreVector[dimy];
             densityPlane.AddPointAt(xVal, yVal);
         }
+        if (delocalizationDistance > (binsize / 2))
+        {
+
+            float delocRequested = delocalizationDistance * delocalizationDistance;
+            float delocRemaining = delocRequested - (binsize * binsize * 0.25f);
+            // gaussian smoothing parameter calculated from this:
+            float gaussianSmoothParam = (float)MathF.Sqrt(2.0f * MathF.PI * delocRemaining);
+            float binsizeOverGaussianSmoothParam = binsize / gaussianSmoothParam;
+            int smoothingCutoffLimit = (int) MathF.Ceiling((1.0f / binsizeOverGaussianSmoothParam) * 1.5f);
+            List<double> smoothCoefficients = new List<double>();
+            for (int h = 0; h <= smoothingCutoffLimit; ++h)
+            {
+                // for gridpoint h, calculate the strength of the 1D gaussian at that 
+                // distance. The gridpoint h is at a distance h * binsize from zero 
+                // so, pass in h as x, and binsizeOverGaussianSmoothParam as inverseG
+                smoothCoefficients.Add(gaussianOfXWithInverseG(h, binsizeOverGaussianSmoothParam));
+            }
+
+            List<float> normalizedCoefficients = normalizeCoefficients(smoothCoefficients); // need these all to add up to one, counting the non-zero values twice
+            
+            // In the case of a small extra delocalization, a gaussian doesn't capture
+            // enough delocalization, because there are not enough buckets in the main part of the curve
+            // In this case, boost the coefficients at -1 and 1 to produce the expected delocalization
+            List<float> adjustedCoefficients = adjustCoefficientsForDeloc(normalizedCoefficients, delocRemaining, binsize);
+
+            // Now, apply the 'gaussian blur' using the coefficients in the 
+            // normalizedCoefficients list.  Loop through each point in 
+            // densityPlane and, for each point, fill the values
+            // in a new densityPlane
+
+            densityPlane = densityPlane.Convolve(normalizedCoefficients);
+         }
+
         return densityPlane;
     }
 
     // CalculateOneDDensities is not used, but here's what it does:
-	// it creates a profile along each of the principal PCA dimensions 
-	// of the density of voxels along that dimension 
-	// That is, peaks in the density profile represent PCA score values with a high population of 
-	// voxels. each Profile is a 'smoothed' histogram of populations 
-	// The AP Suite already has code that produces a similar histogram, displayed
-	// in one of the panes of the PCA Extension.
-	// 
-	// The number of points in the profile is determined by the binsize
-	// If there are points between 0 and 10, there may be 23 entries, from -0.5 to 10.5
-	// at spacings of 0.5
-	//
-	// It can be used like this:
-	//
-	// float binSeparation = 0.5f;
-	// List<DensityProfile> oneDDensities = CalculateOneDDensities(voxelIndices, binSeparation);
+    // it creates a profile along each of the principal PCA dimensions 
+    // of the density of voxels along that dimension 
+    // That is, peaks in the density profile represent PCA score values with a high population of 
+    // voxels. each Profile is a 'smoothed' histogram of populations 
+    // The AP Suite already has code that produces a similar histogram, displayed
+    // in one of the panes of the PCA Extension.
+    // 
+    // The number of points in the profile is determined by the binsize
+    // If there are points between 0 and 10, there may be 23 entries, from -0.5 to 10.5
+    // at spacings of 0.5
+    //
+    // It can be used like this:
+    //
+    // float binSeparation = 0.5f;
+    // List<DensityProfile> oneDDensities = CalculateOneDDensities(voxelIndices, binSeparation);
 
     public List<DensityProfile> CalculateOneDDensities(List<VoxelID> voxelIds, float binsize)
     {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -455,7 +455,7 @@ public class PcaScoresGrid
 
             foreach (List<PixelID> pixelIdList in partitionedIndices)
             {
-                string pcaCode = gridID + "." + peakIndex.ToString();
+                string pcaCode = gridID.ToString() + "." + peakIndex.ToString();
                 // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
                 foreach (PixelID pixelID in pixelIdList)
                 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -437,7 +437,7 @@ public class PcaScoresGrid
         }
         return gridsResults;
     }
-    public PhaseIdResults GetPhasesStrategyE(PcaPhaseIdentificationProperties properties)
+    public PhaseIdResults GetPhasesStrategyE(PcaPhaseIdentificationProperties properties, HashSet<string> gridsToExclude)
     {
         List<VoxelID> voxelIds = pcaVoxels.Keys.ToList();
         int numDimsToInclude = Math.Min(properties.numDimsForPCAPhaseId, this.scoreDims);
@@ -460,43 +460,47 @@ public class PcaScoresGrid
             // for each grid, group the voxels into lists per pixel, then, knowing
             // which peaks contain which pixels, add the voxels PCA code for that grid to its entry in 
             // the PCA code dictionary
+
             TwoDGridID gridID = kvp.Key;
-            DensityPlane twoDGrid = twoDGrids[gridID];
-            List<List<PixelID>> partitionedIndices = kvp.Value;
-            (int firstDim, int secondDim) = gridID.AsIndexPair();
-
-            Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, firstDim, secondDim);
-            int peakIndex = 1;
-
-            foreach (List<PixelID> pixelIdList in partitionedIndices)
+            if (!gridsToExclude.Contains(gridID.ToString()))
             {
-                string pcaCode = gridID.ToString() + "." + peakIndex.ToString();
-                // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
-                foreach (PixelID pixelID in pixelIdList)
+                DensityPlane twoDGrid = twoDGrids[gridID];
+                List<List<PixelID>> partitionedIndices = kvp.Value;
+                (int firstDim, int secondDim) = gridID.AsIndexPair();
+
+                Dictionary<PixelID, List<VoxelID>> voxelLists = aggregateVoxelsIntoListsPerPixel(voxelIds, twoDGrid, pcaVoxels, firstDim, secondDim);
+                int peakIndex = 1;
+
+                foreach (List<PixelID> pixelIdList in partitionedIndices)
+                {
+                    string pcaCode = gridID.ToString() + "." + peakIndex.ToString();
+                    // the pixelIdList contains a list of pixelIds identified as being part of the Nth partition
+                    foreach (PixelID pixelID in pixelIdList)
+                    {
+                        // Lookup for all the voxels bucketed under this pixelId
+                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                        {
+                            pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
+                        }
+                        // remove that entry from voxelLists
+                        voxelLists.Remove(pixelID);
+                    }
+                    peakIndex += 1;
+                }
+
+                // now, all the remaining entries in voxelLists are unassigned :  
+                // assign these to component 0
+                string unassignedPcaCode = gridID.ToString() + ".0";
+                List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
+                foreach (PixelID pixelID in unassignedPixels)
                 {
                     // Lookup for all the voxels bucketed under this pixelId
                     List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
                     foreach (VoxelID voxelId in voxelIdsForThisPixel)
                     {
-                        pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
+                        pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(unassignedPcaCode);
                     }
-                    // remove that entry from voxelLists
-                    voxelLists.Remove(pixelID);
-                }
-                peakIndex += 1;
-            }
-
-            // now, all the remaining entries in voxelLists are unassigned :  
-            // assign these to component 0
-            string unassignedPcaCode = gridID.ToString() + ".0";
-            List<PixelID> unassignedPixels = voxelLists.Keys.ToList();
-            foreach (PixelID pixelID in unassignedPixels)
-            {
-                // Lookup for all the voxels bucketed under this pixelId
-                List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                foreach (VoxelID voxelId in voxelIdsForThisPixel)
-                {
-                    pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(unassignedPcaCode);
                 }
             }
         }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
@@ -30,6 +30,12 @@ public struct TwoDGridID : IComparable<TwoDGridID>
         char cha = (char)(AAsciiValue + index);
         return cha.ToString();
     }
+    public static int IndexForGridLetter(char letter)
+    {
+        int AAsciiValue = (int)'A'; 
+        int gridLetterAsciiValue = (int)letter;
+        return gridLetterAsciiValue - AAsciiValue;
+    }
     public string ToString()
     {
         return stringValue;
@@ -37,11 +43,8 @@ public struct TwoDGridID : IComparable<TwoDGridID>
 
     public (int, int) AsIndexPair()
     {
-        int AAsciiValue = (int)'A';
-        char firstLetter = stringValue[0];
-        char secondLetter = stringValue[1];
-        int firstIndex = (int)firstLetter - AAsciiValue;
-        int secondIndex = (int)secondLetter - AAsciiValue;
+        int firstIndex = IndexForGridLetter((char)stringValue[0]);
+        int secondIndex = IndexForGridLetter((char)stringValue[1]);
         return (firstIndex, secondIndex);
     }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System;
+using Prism.Regions;
+using System.Runtime.CompilerServices;
+using System.Windows.Documents;
+using System.Security.Cryptography;
+using System.Windows.Input;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.IO;
+using System.Xml.Schema;
+using Cameca.CustomAnalysis.Interface;
+
+public struct TwoDGridID : IComparable<TwoDGridID>
+{
+    string stringValue;
+
+
+    public TwoDGridID(int firstDim, int secondDim)
+    {
+        string firstLetter = GridLetterForIndex(firstDim);
+        string secondLetter = GridLetterForIndex(secondDim);
+        this.stringValue = firstLetter + secondLetter;
+    }
+
+    public static string GridLetterForIndex(int index)
+    {
+        int AAsciiValue = (int)'A';
+        char cha = (char)(AAsciiValue + index);
+        return cha.ToString();
+    }
+    public string ToString()
+    {
+        return stringValue;
+    }
+
+    public (int, int) AsIndexPair()
+    {
+        int AAsciiValue = (int)'A';
+        char firstLetter = stringValue[0];
+        char secondLetter = stringValue[1];
+        int firstIndex = (int)firstLetter - AAsciiValue;
+        int secondIndex = (int)secondLetter - AAsciiValue;
+        return (firstIndex, secondIndex);
+    }
+
+    public int CompareTo(TwoDGridID other)
+    {
+        return stringValue.CompareTo(other.stringValue) ;
+    }
+}
+ 
+ 
+
+
+
+
+


### PR DESCRIPTION
The PCA phase identification is broken into a 'grid generation' step and a 'phase identification' step.  After grid generation, individual grids can be selected / deselected for use in the PCA phase identification step.

after a phase identification is run, going back to the grids and changing the inclusion of a grid will invalidate the PCA phases.

Grid letters correspond to PCA dimensions -- dimension index 0 is A, dimension index 1 is B, etc., so that grid "AC" means the 2D projection of the PCA scores onto dimensions 0 and 2.  A PCA code of  "AC1" means that a particular voxel is included in the first peak identified in the grid AC.

The grid generation now also has an additional "delocalization" parameter.  Grids currently has a default binsize of 0.5, and generating these grids implicitly produces a delocalization of 0.25 (L/2).  Setting a relocation of higher than L/2 results in additional delocalization of the grid values.  Choosing different combinations of bin size and delocalization (as well as noise floor and peak summit allowance) might produce projections with more or fewer peaks identified. 

