### PR TITLE
Improve scores histogram UI

### DIFF
--- a/Cameca.CustomAnalysis.Pca/Interfaces/HistogramsUsageDelegate.cs
+++ b/Cameca.CustomAnalysis.Pca/Interfaces/HistogramsUsageDelegate.cs
@@ -1,0 +1,29 @@
+﻿using Cameca.CustomAnalysis.Interface;
+using CommunityToolkit.Mvvm.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Cameca.CustomAnalysis.Pca;
+
+
+public interface IHistogramsUsageDelegate
+{
+    void UseHistogramForPca(string histogramID, bool useIt);
+    bool UsesHistogramForPca(string histogramID);
+}
+
+public class DoNothingHistogramsUsageDelegate : IHistogramsUsageDelegate
+{
+    public DoNothingHistogramsUsageDelegate()
+    {
+    }
+
+    public void UseHistogramForPca(string gridID, bool useIt)
+    {
+
+    }
+
+    public bool UsesHistogramForPca(string gridID)
+    {
+        return true;
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/Interfaces/HistogramsUsageDelegate.cs
+++ b/Cameca.CustomAnalysis.Pca/Interfaces/HistogramsUsageDelegate.cs
@@ -4,13 +4,18 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Cameca.CustomAnalysis.Pca;
 
-
+/// IHistogramsUsageDelegate is used to communicate changes from the UI back to the model about
+/// which oneDGrids (PCA histograms) to use in the PCA Phase determination process
+/// The main class can implement this protocol and then inject itself as a delegate for
+/// the UI
 public interface IHistogramsUsageDelegate
 {
     void UseHistogramForPca(string histogramID, bool useIt);
     bool UsesHistogramForPca(string histogramID);
 }
 
+/// DoNothingHistogramsUsageDelegate is the default implementation of the delegate
+/// so that the UI can be initialized with a default (or tested separately from the modedl)
 public class DoNothingHistogramsUsageDelegate : IHistogramsUsageDelegate
 {
     public DoNothingHistogramsUsageDelegate()

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentResults.cs
@@ -1,6 +1,5 @@
 ﻿namespace Cameca.CustomAnalysis.Pca;
 
-
 // public rather than internal because a ComponentsResults object is used to 
 // call the PhaseIdResults constructor
 public sealed class ComponentResults

--- a/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/ComponentsResults.cs
@@ -1,6 +1,4 @@
 ﻿using Cameca.CustomAnalysis.Interface;
-using System;
-using System.Linq;
 using System.Collections.Generic;
 
 namespace Cameca.CustomAnalysis.Pca;

--- a/Cameca.CustomAnalysis.Pca/Models/PhaseIDResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/PhaseIDResults.cs
@@ -1,7 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using System;
-using Cameca.CustomAnalysis.Pca;
 
 // PhaseIDResults represents an assignment of each voxel to an integer phase.
 // in the identifiedPhase Dictionary, the Key is a VoxelID, and the value is its 'phase', 

--- a/Cameca.CustomAnalysis.Pca/Models/TwoDGridsResults.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/TwoDGridsResults.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
-using System;
 using Cameca.CustomAnalysis.Pca;
 // TwoDGridsResults represents the projection of the PCA Components results
 // onto two dimensional drids for different pairs of axes

--- a/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/TwoDPeakProjections.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Windows.Documents;
-
+﻿
 namespace Cameca.CustomAnalysis.Pca;
 
 public sealed class TwoDPeakProjection

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -101,7 +101,16 @@
                     </Grid>
                 </utils:ButtonOverlayControl>
             </TabItem>
-
+            
+            <TabItem Header="Scores">
+                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
+                            ButtonContent="Update"
+                            OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <local:ScoresHistogramsView HistogramsSource="{Binding ScoresHistogramsRenderData}"   
+                                               HistogramsUsageDelegate="{Binding HistogramsUsageDelegate}" />
+                </utils:ButtonOverlayControl>
+            </TabItem>
+            
             <TabItem Header="Grids">
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateGridsCommand}"
                                ButtonContent="Update"
@@ -162,15 +171,6 @@
                 </utils:ButtonOverlayControl>
             </TabItem>
 
-            <TabItem Header="Scores">
-                <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateSelectedComponentCommand}"
-                            ButtonContent="Update"
-                            OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <controls:Chart2D DataSource="{Binding ScoresHistogramData}"
-                                  AxisXLabel="Score"
-                                  AxisYLabel="Voxels"/>
-                </utils:ButtonOverlayControl>
-            </TabItem>
         </TabControl>
     </utils:ButtonOverlayControl>
 </UserControl>

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -106,7 +106,7 @@
                 <utils:ButtonOverlayControl ButtonCommand="{Binding UpdateComponentsCommand}"
                             ButtonContent="Update"
                             OverlayVisibility="{Binding UpdateComponentsCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
-                    <local:ScoresHistogramsView HistogramsSource="{Binding ScoresHistogramsRenderData}"   
+                    <local:ScoresHistogramsView HistogramsSource="{Binding ScoresHistogramRenderData}"   
                                                HistogramsUsageDelegate="{Binding HistogramsUsageDelegate}" />
                 </utils:ButtonOverlayControl>
             </TabItem>

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -148,6 +148,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         return histogramsToUseForPCA.Contains(gridID);
     }
+    
     public void UseHistogramForPca(string gridID, bool useIt)
     {
         if (useIt)
@@ -365,7 +366,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             PcaGridsResults = PcaCalculator.CalculateTwoDGrids(ScoresGrid, pcaPhaseIdProperties);
         }
     }
-
 
     // Uses the component data (or computes for all componets if necessary) to generate plots for the selected component by index
     [RelayCommand(CanExecute = nameof(UpdateSelectedComponentCanExecute))]

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -718,7 +718,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             }
         }
         ReadOnlyMemory2D<float> rom = new ReadOnlyMemory2D<float>(dat, span, span);
-        Vector2 binsize = new Vector2(0.5f, 0.5f); // Vector2(dp.binsize, dp.binsize);
+        Vector2 binsize = new Vector2(dp.binsize, dp.binsize);
         Vector2 origin = new Vector2(minCoord.y * dp.binsize, minCoord.x * dp.binsize);
         renderData.Update(rom, binsize, origin);
     }

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -305,24 +305,29 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         // Scores Histogram
         List<IRenderData> newHistogramsData = new List<IRenderData>();
-
+        int componentIndex = 0;
         foreach (ComponentResults componentResults in componentsResults.Components)
         {
             float[] scores = componentResults.Scores;
             int voxels = scores.Length;
-            float binSize = 0.01f;
+            float binSize = 0.02f;
+            float invBinSize = 1.0f / binSize;
             float min = scores.Min();
             float max = scores.Max();
             int binCount = (int)Math.Ceiling((max - min) / binSize);
-            var binnedScores = new int[binCount];
+            var binnedScores = new int[binCount]; // the y axis of the histogram should be in units of Voxels/PCA Unit
+                                                  // so that changing the binsize doesn't change the score
+            var normalizedScores = new float[binCount];
             for (int i = 0; i < scores.Length; i++)
             {
                 int index = (int)((scores[i] - min) / binSize);
-                binnedScores[index]++;
+                binnedScores[index] += 1;
             }
-            var scoreData = binnedScores.Select((y, i) => new Vector2(min + (i * binSize), y)).ToArray();
+            var scoreData = binnedScores.Select((y, i) => new Vector2(min + (i * binSize), y * invBinSize)).ToArray();
             var scoresHistogram = Resources.ChartObjects.CreateHistogram (scoreData, color: Colors.Blue);
+            scoresHistogram.Name = "PCA Component " + componentIndex;
             newHistogramsData.Add(scoresHistogram);
+            ++componentIndex;
         }
         ScoresHistogramRenderData = newHistogramsData;
 

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -23,11 +23,13 @@ using System.Runtime.Intrinsics.Arm;
 using Cameca.Extensions.Controls;
 using Cameca.CustomAnalysis.Pca;
 using System.Xaml;
+using System.Diagnostics.Metrics;
+using System.Resources;
 
 namespace Cameca.CustomAnalysis.Pca;
 
 [DefaultView(PcaViewModel.UniqueId, typeof(PcaViewModel))]
-internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaProperties>, IGridsUsageDelegate
+internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaProperties>, IGridsUsageDelegate, IHistogramsUsageDelegate
 {
     private readonly INodeDataProvider nodeDataProvider;
     private readonly IOptionsAccessor optionsAccessor;
@@ -50,10 +52,16 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private IColorMap? componentsColorMap = null;
 
     [ObservableProperty]
+    public ICollection<IRenderData> scoresHistogramRenderData = Array.Empty<IRenderData>();
+
+    [ObservableProperty]
     private ICollection<IRenderData> selectedGridRenderData = Array.Empty<IRenderData>();
 
     [ObservableProperty]
     private IGridsUsageDelegate gridsUsageDelegate = new DoNothingGridsUsageDelegate();
+
+    [ObservableProperty]
+    private IHistogramsUsageDelegate histogramsUsageDelegate = new DoNothingHistogramsUsageDelegate();
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(UpdateCommand))]
@@ -67,7 +75,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateComponentsCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateComponentsCommand))]
-    private ComponentsResults? pcaComponentsResults; 
+    private ComponentsResults? pcaComponentsResults;
 
     [ObservableProperty]
     private PcaScoresGrid? scoresGrid = null;
@@ -92,12 +100,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
     public ICollection<string> loadingsLabels = Array.Empty<string>();
 
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
-    [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
-    public ICollection<IRenderData> scoresHistogramData = Array.Empty<IRenderData>();
-
     public bool UpdateComponentsCanExecute => PcaComponentsResults is null;
     public bool UpdateGridsCanExecute => PcaGridsResults is null;
     public bool UpdatePCAPhasesCanExecute => PcaPhaseIDResults is null;
@@ -105,11 +107,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
 
     public bool UpdateSelectedComponentCanExecute =>
-        !LoadingsSeries.Any() || !LoadingsLabels.Any() || !ScoresHistogramData.Any();
+        !LoadingsSeries.Any() || !LoadingsLabels.Any() || !ScoresHistogramRenderData.Any();
 
     public Func<double, string> AxisYLabelFormatter { get; } = (double value) => value.ToString("F3");
 
     internal HashSet<string> gridsToExcludeFromPCA = new HashSet<string>();
+    internal HashSet<string> histogramsToUseForPCA = new HashSet<string>();
     public PrincipalComponentAnalysis(
         IStandardAnalysisFilterNodeBaseServices services,
         ResourceFactory resourceFactory,
@@ -120,12 +123,14 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         this.nodeDataProvider = nodeDataProvider;
         this.optionsAccessor = optionsAccessor;
         this.gridsUsageDelegate = this;
+        this.histogramsUsageDelegate = this;
     }
 
     public bool UsesGridForPca(string gridID)
     {
         return !gridsToExcludeFromPCA.Contains(gridID);
     }
+
     public void UseGridForPca(string gridID, bool useIt)
     {
         if (useIt)
@@ -135,6 +140,23 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         else
         {
             gridsToExcludeFromPCA.Add(gridID);
+        }
+        InvalidatePcaPhases();
+    }
+
+    public bool UsesHistogramForPca(string gridID)
+    {
+        return histogramsToUseForPCA.Contains(gridID);
+    }
+    public void UseHistogramForPca(string gridID, bool useIt)
+    {
+        if (useIt)
+        {
+            histogramsToUseForPCA.Add(gridID);
+        }
+        else
+        {
+            histogramsToUseForPCA.Remove(gridID);
         }
         InvalidatePcaPhases();
     }
@@ -252,12 +274,63 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             Properties.ComponentIndex = Properties.NumberOfComponents;
         }
 
+        await UpdateHistograms(cancellationToken);
+        await UpdateGrids(cancellationToken);
         await UpdateSelectedComponent(cancellationToken);
     }
 
-    // PCA Phases can be updated independently of the Components if the number of grids to use changes
-    // or if any of the properties to use in the calculation change
     [RelayCommand(CanExecute = nameof(UpdateGridsCanExecute))]
+    public async Task UpdateHistograms(CancellationToken cancellationToken)
+    {
+        DataStateIsError = false;
+        if (await Resources.GetIonData(cancellationToken: cancellationToken) is not { } ionData)
+        {
+            DataStateIsError = true;
+            return;
+        }
+
+        var gridNode = Resources.GetGrid();
+        if (gridNode is null || await gridNode.GetDataAsync<IGrid3DData>(cancellationToken: cancellationToken) is not { } gridData)
+        {
+            DataStateIsError = true;
+            return;
+        }
+
+        if (PcaComponentsResults is null)
+        {
+            await UpdateComponents(cancellationToken);
+        }
+
+        var componentsResults = PcaComponentsResults;
+
+        // Scores Histogram
+        List<IRenderData> newHistogramsData = new List<IRenderData>();
+
+        foreach (ComponentResults componentResults in componentsResults.Components)
+        {
+            float[] scores = componentResults.Scores;
+            int voxels = scores.Length;
+            float binSize = 0.01f;
+            float min = scores.Min();
+            float max = scores.Max();
+            int binCount = (int)Math.Ceiling((max - min) / binSize);
+            var binnedScores = new int[binCount];
+            for (int i = 0; i < scores.Length; i++)
+            {
+                int index = (int)((scores[i] - min) / binSize);
+                binnedScores[index]++;
+            }
+            var scoreData = binnedScores.Select((y, i) => new Vector2(min + (i * binSize), y)).ToArray();
+            var scoresHistogram = Resources.ChartObjects.CreateHistogram (scoreData, color: Colors.Blue);
+            newHistogramsData.Add(scoresHistogram);
+        }
+        ScoresHistogramRenderData = newHistogramsData;
+
+
+    }
+// PCA Phases can be updated independently of the Components if the number of grids to use changes
+// or if any of the properties to use in the calculation change
+[RelayCommand(CanExecute = nameof(UpdateGridsCanExecute))]
     public async Task UpdateGrids(CancellationToken cancellationToken)
     {
         DataStateIsError = false;
@@ -273,9 +346,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             DataStateIsError = true;
             return;
         }
-        
-        var compResults = PcaComponentsResults;
 
+        if (PcaComponentsResults is null)
+        {
+           await UpdateComponents(cancellationToken);
+        }
+
+        var compResults = PcaComponentsResults;
         if (compResults != null)
         {
             var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
@@ -283,29 +360,13 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             PcaGridsResults = PcaCalculator.CalculateTwoDGrids(ScoresGrid, pcaPhaseIdProperties);
         }
     }
-    
-    // PCA Phases can be updated independently of the Components and grids   if the number of grids to use changes
-    // or if any of the properties to use in the calculation change
-    [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
-    public async Task UpdatePCAPhases(CancellationToken cancellationToken)
-    {
 
-        var scoresGrid = ScoresGrid;
-        var gridsResults = PcaGridsResults;
-
-        if ((scoresGrid != null) && (gridsResults != null))
-        {
-            var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
-            PcaPhaseIDResults = scoresGrid.GetPhasesStrategyE(pcaPhaseIdProperties, gridsToExcludeFromPCA);
-        }
-    }
 
     // Uses the component data (or computes for all componets if necessary) to generate plots for the selected component by index
     [RelayCommand(CanExecute = nameof(UpdateSelectedComponentCanExecute))]
     public async Task UpdateSelectedComponent(CancellationToken cancellationToken)
     {
         LoadingsLabels = Array.Empty<string>();
-        ScoresHistogramData = Array.Empty<IRenderData>();
 
         if (await Resources.GetIonData(cancellationToken: cancellationToken) is not { } ionData)
         {
@@ -315,10 +376,12 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
 
         int numComponents = Properties.NumberOfComponents;
         int selectedIndex = Properties.ComponentIndex;
-        
-        if (PcaComponentsResults is null){
+
+        if (PcaComponentsResults is null)
+        {
             await UpdateComponents(cancellationToken);
         }
+
         if (PcaComponentsResults?.Components.ElementAtOrDefault(selectedIndex) is not { Scores: { } scores, Loads: { } loadingData })
         {
             return;
@@ -351,24 +414,22 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
             series
         };
         LoadingsLabels = ions.Select(x => x.Name).ToList();
+   }
 
-        // Scores Histogram
-        int voxels = scores.Length;
-        float binSize = 0.01f;
-        float min = scores.Min();
-        float max = scores.Max();
-        int binCount = (int)Math.Ceiling((max - min) / binSize);
-        var binnedScores = new int[binCount];
-        for (int i = 0; i < scores.Length; i++)
+    // PCA Phases can be updated independently of the Components and grids   if the number of grids to use changes
+    // or if any of the properties to use in the calculation change
+    [RelayCommand(CanExecute = nameof(UpdatePCAPhasesCanExecute))]
+    public async Task UpdatePCAPhases(CancellationToken cancellationToken)
+    {
+
+        var scoresGrid = ScoresGrid;
+        var gridsResults = PcaGridsResults;
+
+        if ((scoresGrid != null) && (gridsResults != null))
         {
-            int index = (int)((scores[i] - min) / binSize);
-            binnedScores[index]++;
+            var pcaPhaseIdProperties = new PcaPhaseIdentificationProperties(Properties.GridProjectionBinSize, Properties.GridProjectionDelocalization, Properties.NoiseFloorFraction, Properties.PeakSummitAllowance, Properties.NumberOfComponents);
+            PcaPhaseIDResults = scoresGrid.GetPhasesStrategyE(pcaPhaseIdProperties, gridsToExcludeFromPCA);
         }
-        var scoreData = binnedScores.Select((y, i) => new Vector2(min + (i * binSize), y)).ToArray();
-        var scoresHistogram = Resources.ChartObjects.CreateHistogram(
-            scoreData,
-            color: Colors.Blue);
-        ScoresHistogramData = new IRenderData[] { scoresHistogram };
     }
 
     // Updates the noise eigenvalues tab plot when the computed eigenvalue data changes
@@ -796,7 +857,6 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     {
         LoadingsSeries = new SeriesCollection();
         LoadingsLabels = Array.Empty<string>();
-        ScoresHistogramData = Array.Empty<IRenderData>();
     }
 
     private void InvalidateAll()

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
@@ -66,6 +66,6 @@
                 Grid.Column="2" 
                 Grid.Row="1"                                  
                 AxisXLabel="Score"
-                AxisYLabel="Voxels"/>
+                AxisYLabel="Voxels per PCA Unit"/>
      </Grid>
 </UserControl>

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
@@ -1,0 +1,71 @@
+﻿<UserControl x:Class="Cameca.CustomAnalysis.Pca.ScoresHistogramsView"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:Cameca.CustomAnalysis.Pca"
+             xmlns:interface="clr-namespace:Cameca.CustomAnalysis.Interface;assembly=Cameca.CustomAnalysis.Interface"
+             xmlns:controls="clr-namespace:Cameca.Extensions.Controls;assembly=Cameca.Extensions.Controls"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <UserControl.Resources>
+        <local:SingleRenderDataValueConverter x:Key="SingleRenderDataValueConverter" />
+    </UserControl.Resources>
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Column="0" 
+                    Grid.RowSpan="2"
+                    Orientation="Vertical" 
+                    HorizontalAlignment="Center"
+                    Background="#efefef">
+            <Button x:Name="PreviousHistogramButton" 
+                 Content="Go to Previous Histogram" 
+                 Height="32" 
+                 Width="140"
+                 Click="PreviousHistogramButton_Click" 
+                 Margin="10,10,10,10">
+            </Button>
+            <Button x:Name="AdvanceHistogramButton" 
+                 Content="Advance To Next Histogram" 
+                 Height="32" 
+                 Width="140"
+                 Click="AdvanceHistogramButton_Click" 
+                 Margin="10,10,10,10">
+            </Button>
+            <CheckBox x:Name="UseHistogramForPCAPhaseID" 
+                 Content="Use for PCA Phase ID" 
+                 Height="32" 
+                 Width="140"
+                 Click="UseHistogramForPCAPhaseID_Click" 
+                 Margin="10,10,10,10">
+            </CheckBox>
+            <TextBlock x:Name="HistogramInfoText" 
+                 Width="140"
+                 Margin="10,10,10,10">
+            </TextBlock>
+        </StackPanel>
+        <Label x:Name="HistogramLabel" 
+                 Grid.Column="1" 
+                 Grid.Row="0" 
+                 Content="Histogram Title" 
+                 Height="32" 
+                 Width="140" 
+                 FontSize="16" 
+                 FontFamily="Calibri"  
+                 FontWeight="Bold">
+        </Label>
+        <controls:Chart2D x:Name="ScoresHistogram" 
+                DataSource="{Binding ScoresHistogramRenderData, RelativeSource={RelativeSource AncestorType=local:ScoresHistogramsView}}"
+                Grid.Column="2" 
+                Grid.Row="1"                                  
+                AxisXLabel="Score"
+                AxisYLabel="Voxels"/>
+     </Grid>
+</UserControl>

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
@@ -28,21 +28,21 @@
             <Button x:Name="PreviousHistogramButton" 
                  Content="Go to Previous Histogram" 
                  Height="32" 
-                 Width="140"
+                 Width="170"
                  Click="PreviousHistogramButton_Click" 
                  Margin="10,10,10,10">
             </Button>
             <Button x:Name="AdvanceHistogramButton" 
                  Content="Advance To Next Histogram" 
                  Height="32" 
-                 Width="140"
+                 Width="170"
                  Click="AdvanceHistogramButton_Click" 
                  Margin="10,10,10,10">
             </Button>
             <CheckBox x:Name="UseHistogramForPCAPhaseID" 
                  Content="Use for PCA Phase ID" 
                  Height="32" 
-                 Width="140"
+                 Width="170"
                  Click="UseHistogramForPCAPhaseID_Click" 
                  Margin="10,10,10,10">
             </CheckBox>

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml.cs
@@ -14,7 +14,10 @@ using System.Windows.Media;
 namespace Cameca.CustomAnalysis.Pca;
 
 /// <summary>
-/// Interaction logic for ProjectionGridsView.xaml
+/// Interaction logic for ScoresHistogramsView.xaml
+/// This is the pane which shows a histogram of number of voxels with a particular PCA score in a PCA dimension
+/// And can cycle through the different grids with the Advance / Move Back buttons
+/// There is an (as yet unused) button for 'use this dimension in the PCA Phase determination'
 /// </summary>
 public partial class ScoresHistogramsView : UserControl
 {

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml.cs
@@ -1,0 +1,156 @@
+﻿using Cameca.CustomAnalysis.Interface;
+using Cameca.CustomAnalysis.Utilities;
+using Cameca.Extensions.Controls;
+using CommunityToolkit.HighPerformance;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+using System.Windows.Media;
+
+namespace Cameca.CustomAnalysis.Pca;
+
+/// <summary>
+/// Interaction logic for ProjectionGridsView.xaml
+/// </summary>
+public partial class ScoresHistogramsView : UserControl
+{
+    string currentHistogramId = "";
+    HashSet<string> histogramsToUseForPCAPhaseID = new HashSet<string>();
+    int whichHistogram = 0;
+    public ScoresHistogramsView()
+    {
+        InitializeComponent();
+        var histogram = ScoresHistogram;
+    }
+
+    public static readonly DependencyProperty HistogramsSourceProperty = DependencyProperty.Register(
+        nameof(HistogramsSource),
+        typeof(ICollection<IRenderData>),
+        typeof(ScoresHistogramsView),
+        new FrameworkPropertyMetadata(Array.Empty<IRenderData>(), HistogramsSourcePropertyChanged));
+
+    // GridsUsageProtocol is an object that can accept notifications of whether o not to use a particular grid as 
+    // part of the PCA Phase identification process.  So, when the "Use this grid in PCA Phase ID" button is clicked
+    // this object will get notified of the user intent.
+    public static readonly DependencyProperty HistogramsUsageDelegateProperty = DependencyProperty.Register(
+            nameof(HistogramsUsageDelegate),
+            typeof(IHistogramsUsageDelegate),
+            typeof(ScoresHistogramsView),
+            new FrameworkPropertyMetadata(new DoNothingHistogramsUsageDelegate(), HistogramsUsageDelegatePropertyChanged));
+
+    private static void HistogramsUsageDelegatePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+    }
+
+    private static void HistogramsSourcePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not ScoresHistogramsView scoresHistogramsView) { return; }
+        ICollection<IRenderData> renderData = scoresHistogramsView.HistogramsSource;
+        scoresHistogramsView.RefreshHistogramData();
+    }
+
+    private void HistogramsSourceCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        RefreshHistogramData();
+    }
+
+    // 
+    internal string AxisXLabelForHistogramID(string histogramID)
+    {
+        return histogramID;
+    }
+
+
+    private void RefreshHistogramData()
+    { 
+        ICollection<IRenderData> renderDataCollection = this.HistogramsSource;
+        int rdc = renderDataCollection.Count;
+ 
+        if (rdc > 0)
+        {
+            List<IRenderData> renderList = renderDataCollection.ToList();
+
+            if (whichHistogram >= rdc)
+            {
+                whichHistogram = 0;
+            }
+            if (whichHistogram < 0)
+            {
+                whichHistogram = rdc - 1;
+            }
+
+            var renderData = renderList[whichHistogram];
+            currentHistogramId = renderData.Name;
+            List<IRenderData> singleList = new List<IRenderData> { renderData };
+            Chart2D histogram = ScoresHistogram;
+            //for whatever reason, for grid PQ, we seem to have put the P in the Y axis, and the Q in the Z axis
+            // so, the X axis gets its name from the second letter in the grid ID
+            histogram.AxisXLabel = AxisXLabelForHistogramID(renderData.Name); 
+            histogram.DataSource = singleList;
+            histogram.IsLegendVisible = true;
+            Label histogramLabel = HistogramLabel;
+            histogramLabel.Content = "Histogram " + renderData.Name;
+
+            UseHistogramForPCAPhaseID.IsChecked = HistogramsUsageDelegate.UsesHistogramForPca(currentHistogramId);
+        }
+    }
+
+    public IHistogramsUsageDelegate HistogramsUsageDelegate
+    {
+        get { return (IHistogramsUsageDelegate)GetValue(HistogramsUsageDelegateProperty); }
+        set
+        {
+            SetValue(HistogramsUsageDelegateProperty, value);
+        }
+    }
+
+    public ICollection<IRenderData> HistogramsSource
+    {
+        get { return (ICollection<IRenderData>)GetValue(HistogramsSourceProperty); }
+        set
+        {
+            SetValue(HistogramsSourceProperty, value);
+            RefreshHistogramData();
+        }
+    }
+
+    private void AdvanceHistogramButton_Click(object sender, RoutedEventArgs e)
+    {
+        whichHistogram += 1;
+        RefreshHistogramData();
+    }
+    private void PreviousHistogramButton_Click(object sender, RoutedEventArgs e)
+    {
+        whichHistogram -= 1;
+        RefreshHistogramData();
+    }
+    private void UseHistogramForPCAPhaseID_Click(object sender, RoutedEventArgs e)
+    {
+        CheckBox checkBox = (CheckBox)sender;
+        bool? checkBoxChecked = checkBox.IsChecked;
+        bool isChecked = checkBoxChecked.HasValue ? checkBoxChecked.Value : true;
+        HistogramsUsageDelegate.UseHistogramForPca(currentHistogramId, isChecked);
+    }
+
+    
+    private static IEnumerable<T> GetChildren<T>(DependencyObject root) where T: DependencyObject
+    {
+        int childrenCount = VisualTreeHelper.GetChildrenCount(root);
+        for (int i = 0; i < childrenCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(root, i);
+            if (child is T)
+            {
+                yield return (T)child;
+            }
+            foreach (var recursiveChild in GetChildren<T>(child))
+            {
+                yield return recursiveChild;
+            }
+        }
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/CandidateRanker.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/CandidateRanker.cs
@@ -1,8 +1,4 @@
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System;
-using System.IO;
  
 // CandidateRanker is used to identify the 'best' candidates from all the PixelSuggestion 
 // objects it is asked to consider. Items added to the list of candidates are the 'best'

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -14,7 +14,11 @@ using System.Security.Cryptography.X509Certificates;
 public struct PixelID : IComparable<PixelID>
 {
     public int pixelId;
-    static int maxgrid = 510;
+    // each grid row has potentially 2^10 pixelID (i.e. 1024 -- not all actually used)
+    public const int GridStrideExp = 10;
+    public const int GridStride = 1 << GridStrideExp;
+    public const int HalfGridStride = 1 << (GridStrideExp - 1); // pixel ids advance 1024 from one row to the next
+    public const int Maxgrid = HalfGridStride - 2; // buckets from -510 to 510 are possible
 
     public PixelID(int pixelId)
     {
@@ -23,17 +27,18 @@ public struct PixelID : IComparable<PixelID>
 
     public static PixelID? PixelIDFor(int x, int y)
     {
-        if ((x > maxgrid) || (x < -maxgrid) || (y > maxgrid) || (y < -maxgrid))
+        if ((x > Maxgrid) || (x < -Maxgrid) || (y > Maxgrid) || (y < -Maxgrid))
         {
             return null;
         }
-        return new PixelID(y * 1024 + x);
+        int newId = y * GridStride + x;
+        return new PixelID(newId);
     }
 
     public (int, int) xyCoords()
     {
-        int y = (512 + pixelId) >> 10;
-        int x = pixelId - (y * 1024);
+        int y = (HalfGridStride + pixelId) >> GridStrideExp;
+        int x = pixelId - (y * GridStride);
         return (x, y);
     }
 
@@ -111,7 +116,7 @@ public class DensityPlane
         oobPoints = 0;
         oneOverBinsize = 1.0f / binSep;
         data = new Dictionary<PixelID, float>();
-        maxval = 1022.0f * binSep;
+        maxval = PixelID.Maxgrid * binSep;
     }
 
     public delegate void ForEachPixelCallback(PixelID pixelId, float value);
@@ -363,8 +368,12 @@ public class DensityPlane
 
     public float valueAtGridCoords(int x, int y)
     {
-        PixelID pixelId = this.BinFor(x, y);
-        return this.valueAtPixel(pixelId);
+        PixelID? pixelId = PixelID.PixelIDFor(x, y);
+        if (pixelId == null)
+        {
+            return 0.0f;
+        }
+        return this.valueAtPixel(pixelId.Value);
     }
 
     public float valueAtPixel(PixelID pixelId)
@@ -375,11 +384,6 @@ public class DensityPlane
             return binValue;
         }
         return 0.0f;
-    }
-
-    public PixelID BinFor(int x, int y)
-    {
-        return new PixelID(y * 1024 + x);
     }
 
     public (int, int) PixelIndicesFor(float x, float y)
@@ -428,6 +432,10 @@ public class DensityPlane
             }
         }
 
+        if ((x < -1.0f)  || (y < -1.0f))
+        {
+            Debug.Assert(true);
+        }
         int xBinIndex;
         int yBinIndex;
         (xBinIndex, yBinIndex) = PixelIndicesFor(x, y);

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -14,7 +14,12 @@ using System.Security.Cryptography.X509Certificates;
 public struct PixelID : IComparable<PixelID>
 {
     public int pixelId;
-    // each grid row has potentially 2^10 pixelID (i.e. 1024 -- not all actually used)
+    
+    // Here are some hardcoded constants for maintaining the grid data
+    // each grid row has potentially 2^10 pixelIDs per row (i.e. 1024 -- not all actually used)
+    // advancing the y index by one advances the pixel ID by 1024
+    // pixe3l ID 0 refers to the pixel at 0,0
+    // other constants are defined here for ease of calculation later
     public const int GridStrideExp = 10;
     public const int GridStride = 1 << GridStrideExp;
     public const int HalfGridStride = 1 << (GridStrideExp - 1); // pixel ids advance 1024 from one row to the next
@@ -100,6 +105,11 @@ public struct PeakID
 //   1/64   3/32   1/64
 //   3/32   9/16   3/32 
 //   1/64   3/32   1/64
+//
+// Pixel data is not kept in a 2D array -- 
+// Rather, a dictionary is kept with the key being the PixelID
+// This is memory efficient, because the grid is likely sparsely populated, and lookup
+// efficient, as the PixelID is really represented by an integer
 public class DensityPlane
 {
     float halfBinsize;
@@ -432,10 +442,6 @@ public class DensityPlane
             }
         }
 
-        if ((x < -1.0f)  || (y < -1.0f))
-        {
-            Debug.Assert(true);
-        }
         int xBinIndex;
         int yBinIndex;
         (xBinIndex, yBinIndex) = PixelIndicesFor(x, y);
@@ -459,9 +465,7 @@ public class DensityPlane
         addValueAtCoords(xBinIndex - 1, yBinIndex + 1, xm1 * yp1);
         addValueAtCoords(xBinIndex, yBinIndex + 1, x0 * yp1);
         addValueAtCoords(xBinIndex + 1, yBinIndex + 1, xp1 * yp1);
-
     }
-
 }
 
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -1,15 +1,10 @@
 
 using System;
 using System.IO;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.Intrinsics.Arm;
-using System.Windows.Controls;
-using System.Text.RegularExpressions;
-using System.Security.Cryptography.X509Certificates;
+
 
 public struct PixelID : IComparable<PixelID>
 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System;
-using System.IO;
 
 // DensityProfile represents a histogram-ish population along one axis
 // Bins are regularly spaced from the minimum to the maximum

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System;
 using System.IO;
 
-
 // DensityProfile represents a histogram-ish population along one axis
 // Bins are regularly spaced from the minimum to the maximum
 // Bins have an integer id according to their distance from 0
@@ -15,8 +14,8 @@ using System.IO;
 // between bins to preserve a constant smoothing for all added points
 // There is always a bin at zero
 // bins at negative values have negative indices
-// "out of bounds" limits at -1023 and 1023
-//  points outside of the bounds are counted but not binned
+// "out of bounds" limits at -1024 and 1024
+// points outside of the bounds are counted but not binned
 // Points are added to the profile using a splat transfer function, in a way that the 
 // delocalization for every point added to the profile is constant.  That is,
 // if a point is added at the center of a bin, it contributes .75 to that bin and .125 to each neighbor bin
@@ -30,9 +29,12 @@ public class DensityProfile
     float oneOverBinsize;
     int oobPoints;
     Dictionary<int, float> data;
+
+    const int MaxBinIndex = 1024;
+
     public DensityProfile(float binsize)
     {
-        this.maxval = binsize * 1023.0f;
+        this.maxval = binsize * MaxBinIndex;
         this.halfBinsize = binsize * 0.5f;
         this.binsize = binsize;
         this.oneOverBinsize = 1.0f / binsize;

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityProfile.cs
@@ -14,8 +14,6 @@ using System.IO;
 // between bins to preserve a constant smoothing for all added points
 // There is always a bin at zero
 // bins at negative values have negative indices
-// "out of bounds" limits at -1024 and 1024
-// points outside of the bounds are counted but not binned
 // Points are added to the profile using a splat transfer function, in a way that the 
 // delocalization for every point added to the profile is constant.  That is,
 // if a point is added at the center of a bin, it contributes .75 to that bin and .125 to each neighbor bin
@@ -23,18 +21,16 @@ using System.IO;
 
 public class DensityProfile
 {
-    float maxval;
+    float maxPermittedValue;
     float halfBinsize;
     float binsize;
     float oneOverBinsize;
     int oobPoints;
     Dictionary<int, float> data;
 
-    const int MaxBinIndex = 1024;
-
     public DensityProfile(float binsize)
     {
-        this.maxval = binsize * MaxBinIndex;
+        this.maxPermittedValue = binsize * (int.MaxValue -2);
         this.halfBinsize = binsize * 0.5f;
         this.binsize = binsize;
         this.oneOverBinsize = 1.0f / binsize;
@@ -65,7 +61,7 @@ public class DensityProfile
 
     public void AddPointAt(float x)
     {
-        if (Math.Abs(x) > maxval)
+        if (Math.Abs(x) > maxPermittedValue)
         {
             oobPoints += 1;
             return;
@@ -96,7 +92,6 @@ public class DensityProfile
         data[binIndex - 1] = populationAtBin(binIndex - 1) + xm1;
         data[binIndex + 1] = populationAtBin(binIndex + 1) + xp1;
     }
-
 }
 
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaPhaseName.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaPhaseName.cs
@@ -1,9 +1,7 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System;
-using System.IO;
-using Microsoft.Windows.Themes;
+
 
 
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -490,7 +490,6 @@ public class PcaScoresGrid
                             // remove that entry from voxelLists
                             voxelLists.Remove(pixelID);
                         }
- 
                     }
                     peakIndex += 1;
                 }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -1,23 +1,10 @@
 
 using PcaExtensionMethods;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System;
 using System.IO;
-using System.Windows.Controls;
-using System.Collections;
-using System.Windows.Input;
-using System.Text;
-using System.Windows.Media.Animation;
-using System.Reflection.PortableExecutable;
 using Cameca.CustomAnalysis.Pca;
-using System.Runtime.Intrinsics.Arm;
-using System.Net.Http;
-using System.Data.SqlTypes;
-using System.Reflection;
-using System.Windows;
-
 
 // PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
 // PcaScoresGrid is initialized with the size of the grid in x y and z, so that it can then map 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -478,13 +478,19 @@ public class PcaScoresGrid
                     foreach (PixelID pixelID in pixelIdList)
                     {
                         // Lookup for all the voxels bucketed under this pixelId
-                        List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
-                        foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                        // it is possible there are none -- this could happen if the pixel in question is entirely populated by 
+                        // splat components from voxels in adjacent pixels
+                        if (voxelLists.ContainsKey(pixelID))
                         {
-                            pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
+                            List<VoxelID> voxelIdsForThisPixel = voxelLists[pixelID];
+                            foreach (VoxelID voxelId in voxelIdsForThisPixel)
+                            {
+                                pcaCodes[voxelId] = pcaCodes[voxelId].AppendCode(pcaCode);
+                            }
+                            // remove that entry from voxelLists
+                            voxelLists.Remove(pixelID);
                         }
-                        // remove that entry from voxelLists
-                        voxelLists.Remove(pixelID);
+ 
                     }
                     peakIndex += 1;
                 }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaStream.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaStream.cs
@@ -1,10 +1,7 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System;
 using System.IO;
-using Cameca.CustomAnalysis.Interface;
-using System.DirectoryServices.ActiveDirectory;
 
 // PcaStream is a utility class for writing information to a file during a run of the 
 // Pca code in APSuite

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaVoxel.cs
@@ -1,16 +1,5 @@
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System;
-using Prism.Regions;
-using System.Runtime.CompilerServices;
-using System.Windows.Documents;
-using System.Security.Cryptography;
-using System.Windows.Input;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.IO;
-using System.Xml.Schema;
-using Cameca.CustomAnalysis.Interface;
 
 public struct VoxelID : IComparable<VoxelID>
 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PopulationSorter.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PopulationSorter.cs
@@ -1,10 +1,5 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System;
-using System.IO;
-
-
 
 public class PopulationSorter<T, U> : IComparer<T>
 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridID.cs
@@ -1,16 +1,4 @@
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System;
-using Prism.Regions;
-using System.Runtime.CompilerServices;
-using System.Windows.Documents;
-using System.Security.Cryptography;
-using System.Windows.Input;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.IO;
-using System.Xml.Schema;
-using Cameca.CustomAnalysis.Interface;
 
 public struct TwoDGridID : IComparable<TwoDGridID>
 {

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -5,7 +5,6 @@ using System;
 using PcaExtensionMethods;
 using Cameca.CustomAnalysis.Pca;
 
-
 public class TwoDGridPartitionFinder
 {
     DensityPlane grid;

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Diagnostics;
 using System;
 using PcaExtensionMethods;
-
 
 // PixelSuggestion represents a pixel that could be added to a TwoDPeak as part of the PartitionFinder
 // peak partitioning algorithm


### PR DESCRIPTION
Reorder the panels to scores histograms before grids.

Change units of the y axis of the histogram display to be in voxels per unit, so that the numbers don't change when the x axis bin size changes

Add code that can accommodate a checkbox in the UI for each PCA dimension to use its oneD projection in the PCA Phase Determination process.

Fix an issue with the 2D grid display not updating in response to changing the bin size.

Hardcode some constants related to the 2D grid generation so there is only one place they are defined.

And a check for an exceptional case that gets hit with low noise floors -- first noticed by David!


