### PR TITLE
Fix a peak ID issue, put text in TextBox

### DIFF
--- a/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ProjectionGridsView.xaml
@@ -28,28 +28,33 @@
             <Button x:Name="PreviousGridButton" 
                  Content="Go to Previous Grid" 
                  Height="32" 
-                 Width="140"
+                 Width="160"
                  Click="PreviousGridButton_Click" 
                  Margin="10,10,10,10">
             </Button>
             <Button x:Name="AdvanceGridButton" 
                  Content="Advance To Next Grid" 
                  Height="32" 
-                 Width="140"
+                 Width="160"
                  Click="AdvanceGridButton_Click" 
                  Margin="10,10,10,10">
             </Button>
             <CheckBox x:Name="UseGridForPCAPhaseID" 
                  Content="Use Grid for PCA Phase ID" 
                  Height="32" 
-                 Width="140"
+                 Width="160"
                  Click="UseGridForPCAPhaseID_Click" 
                  Margin="10,10,10,10">
             </CheckBox>
-            <TextBlock x:Name="GridInfoText" 
-                 Width="140"
-                 Margin="10,10,10,10">
-            </TextBlock>
+            <TextBox x:Name="GridInfoText" 
+                 Width="160"
+                 Margin="10,10,10,10"
+                 MaxHeight="250"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="True">
+            </TextBox>
+ 
         </StackPanel>
         <Label x:Name="GridLabel" 
                  Grid.Column="1" 

--- a/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
+++ b/Cameca.CustomAnalysis.Pca/ScoresHistogramsView.xaml
@@ -46,10 +46,14 @@
                  Click="UseHistogramForPCAPhaseID_Click" 
                  Margin="10,10,10,10">
             </CheckBox>
-            <TextBlock x:Name="HistogramInfoText" 
-                 Width="140"
-                 Margin="10,10,10,10">
-            </TextBlock>
+            <TextBox x:Name="HistogramInfoText" 
+                 Width="170"
+                 Margin="10,10,10,10"
+                 MaxHeight="250"
+                 ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                 ScrollViewer.VerticalScrollBarVisibility="Auto"
+                 ScrollViewer.CanContentScroll="True">
+            </TextBox>
         </StackPanel>
         <Label x:Name="HistogramLabel" 
                  Grid.Column="1" 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -254,17 +254,27 @@ public class TwoDGridPartitionFinder
                         // its possible we have another peak to find
                         // first. filter any previous identified higherPixels to see if they are now part of a new peak:
                         foundIncreasePixelIds = FilterForAvailableIds(foundIncreasePixelIds);
-                        if (foundIncreasePixelIds.Count > 0)
-                        {
-                            // it is a certainty we still have a peak to find
-                            maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
-                        }
-                        else
+                        maybeMaximumPixelId = grid.FindMaximum(unplacedPixelIds);
+                        if (foundIncreasePixelIds.Count == 0) 
                         {
                             // if a new peak was identified, it has absorbed the pixels we found
                             // we should continue with a lower search floor
-                            maybeMaximumPixelId = null;
                             shouldContinueWithLowerSearchFloor = (noiseFloor < searchFloor);
+
+                            // alternatively, it is possible there is a completely separate peak
+                            // in which case, the previous peak did not find an increase, but we should continue with 
+                            // identifying that new peak.
+                            // in this case, see if maybeMaximumPixelId has a value above the searchFloor
+                            // if it doesn't remove it from consideration
+                            if (maybeMaximumPixelId.HasValue)
+                            {
+                                var nextPixelId = maybeMaximumPixelId.Value;
+                                float nextPixelVal = grid.ValueAtPixel(nextPixelId);
+                                if (nextPixelVal < noiseFloor)
+                                {
+                                    maybeMaximumPixelId = null;
+                                }
+                            }
                         }
                         break;
                     }


### PR DESCRIPTION
Using TextBox instead of TextBlock allows scrolling, text selection.

Peak ID issue was related to peak id issues when peaks were completely separated.