### PR TITLE
Implement wider peak border

### DIFF
--- a/Cameca.CustomAnalysis.Pca/Models/OneDPeakProjections.cs
+++ b/Cameca.CustomAnalysis.Pca/Models/OneDPeakProjections.cs
@@ -12,6 +12,5 @@ public sealed class OneDPeakProjection
         this.densityLine = dl;
     }
 
-  
 }
 

--- a/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaCalculator.cs
@@ -27,7 +27,7 @@ public struct PcaPhaseIdentificationProperties
           int numDimsForPCAPhaseId)
     {
         this.oneDProjectionBinSize = 0.05f;
-        this.oneDProjectionDelocalization = 0.05f; 
+        this.oneDProjectionDelocalization = gridProjectionDelocalization; 
         this.gridProjectionBinSize = gridProjectionBinSize;
         this.gridProjectionDelocalization = gridProjectionDelocalization;
         this.noiseFloorFraction = noiseFloor;

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/DensityPlane.cs
@@ -7,7 +7,17 @@ using System.Linq;
 
 namespace Cameca.CustomAnalysis.Pca.VoxelLogic;
 
-public struct PixelID : IComparable<PixelID>
+public struct PixelCoords
+{
+    public int x;
+    public int y;
+    public PixelCoords(int x, int y)
+    {
+        this.x = x;
+        this.y = y;
+    }
+}
+public struct PixelID : IComparable<PixelID>, IEquatable<PixelID>
 {
     public readonly int pixelId;
     
@@ -36,11 +46,22 @@ public struct PixelID : IComparable<PixelID>
         return new PixelID(newId);
     }
 
-    public readonly (int, int) XYCoords()
+    public PixelCoords PixelCoords()
     {
         int y = (HalfGridStride + pixelId) >> GridStrideExp;
         int x = pixelId - (y * GridStride);
-        return (x, y);
+        return new PixelCoords(x, y);
+    }
+
+    // DSquaredTo is used to measure distance to another pixel,
+    // but if the exact distance is not required, sometimes it is OK to 
+    // return the much simpler distanceSquared (no squareroot required)
+    public int DSquaredTo(PixelCoords coords)
+    {
+        var myCoords = this.PixelCoords();
+        var diffx = myCoords.x = coords.x;
+        var diffy = myCoords.y = coords.y;
+        return (diffx * diffx + diffy * diffy);
     }
 
     public readonly int CompareTo(PixelID other)
@@ -48,10 +69,15 @@ public struct PixelID : IComparable<PixelID>
         return other.pixelId > pixelId ? -1 : other.pixelId < pixelId ? 1 : 0;
     }
 
+    public bool Equals(PixelID other)
+    {
+        return pixelId == other.pixelId;
+    }
+
     public readonly string DebugStr()
     {
-        (int x, int y) = this.XYCoords();
-        return pixelId.ToString() + ":{" + x + "," + y + "}";
+        var coords = this.PixelCoords();
+        return pixelId.ToString() + ":{" + coords.x + "," + coords.y + "}";
     }
 }
 
@@ -144,7 +170,7 @@ public class DensityPlane
             int miny = minx;
             void convolutionFunction(PixelID pixelId, float value)
             {
-                (int p, int q) = pixelId.XYCoords();
+                var coords = pixelId.PixelCoords();
                 for (int x = minx; x <= maxx; x+=1)
                 {
                     int xCoefficientIndex = (int)Math.Abs(x);
@@ -153,7 +179,7 @@ public class DensityPlane
                     {
                         int yCoefficientIndex = (int)Math.Abs(y);
                         float yCoeff = normalizedCoefficients[yCoefficientIndex];
-                        PixelID? nthPixelID = PixelID.PixelIDFor(p + x, q + y);
+                        PixelID? nthPixelID = PixelID.PixelIDFor(coords.x + x, coords.y + y);
                         if (nthPixelID != null)
                         {  
                             newDP.AddValueAtPixel(nthPixelID.Value, value * xCoeff * yCoeff);
@@ -193,7 +219,9 @@ public class DensityPlane
     // check for the 8 neighboring pixels and add them if they have a non-zero value
     public List<PixelID> PixelIdsNeighboring(PixelID pixelId)
     {
-        (int x, int y) = pixelId.XYCoords();
+        var pixelCoords = pixelId.PixelCoords();
+        var x = pixelCoords.x;
+        var y = pixelCoords.y;
         List<PixelID> neighbors = new();
         AddIfNonZero(x - 1, y - 1, neighbors);
         AddIfNonZero(x - 1, y, neighbors);
@@ -254,7 +282,10 @@ public class DensityPlane
         pixelIds.Sort();
         foreach (PixelID pixelId in pixelIds)
         {
-            (int x, int y) = pixelId.XYCoords();
+            var pixelCoords = pixelId.PixelCoords();
+            var x = pixelCoords.x;
+            var y = pixelCoords.y;
+
             if (!first)
             {
                 miny = Math.Min(y, miny);
@@ -333,7 +364,9 @@ public class DensityPlane
         pixelIds.Sort();
         foreach (PixelID pixelId in pixelIds)
         {
-            (int x, int y) = pixelId.XYCoords();
+            var pixelCoords = pixelId.PixelCoords();
+            var x = pixelCoords.x;
+            var y = pixelCoords.y;
             if (!first)
             {
                 miny = Math.Min(y, miny);
@@ -393,8 +426,8 @@ public class DensityPlane
 
     public (float, float) XYCoordsFor(PixelID pixelId)
     {
-        (int xBinIndex, int yBinIndex) = pixelId.XYCoords();
-        return (xBinIndex * binsize, yBinIndex * binsize);
+        var pixelCoords = pixelId.PixelCoords();
+        return (pixelCoords.x * binsize, pixelCoords.y * binsize);
     }
 
     public PixelID? PixelIDFor(float x, float y)

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -247,7 +247,10 @@ public class PcaScoresGrid
                 bool firstCoord = true;
                 foreach (PixelID pixelId in partition)
                 {
-                    (int x, int y) = pixelId.XYCoords();
+                    var pixelCoords = pixelId.PixelCoords();
+                    var x = pixelCoords.x;
+                    var y = pixelCoords.y;
+
                     if (!firstCoord) {
                         outputFile.Write(",");
                     }

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDGridPartitionFinder.cs
@@ -10,10 +10,11 @@ public class TwoDGridPartitionFinder
 {
     readonly DensityPlane grid;
     List<PixelID> unplacedPixelIds;
-    readonly List<PixelID> rejectedPixelIds;
+    readonly HashSet<PixelID> peakBorderPixelIds;
     List<PixelID> foundIncreasePixelIds; // when a peak finds an increase, remember it here
     readonly Dictionary<PeakID, TwoDPeak> peaks;
     PcaPhaseIdentificationProperties properties;
+    readonly float borderExclusionRatio;
 
     // These are the return codes returned by IterateIdentifyingPeaks()
     // Depending on this result, the Logic in FindPartitions will either
@@ -34,15 +35,18 @@ public class TwoDGridPartitionFinder
     {
         this.grid = twoDGrid;
         this.peaks = new Dictionary<PeakID, TwoDPeak> ();
-        this.rejectedPixelIds = new List<PixelID>();
+        this.peakBorderPixelIds = new HashSet<PixelID>();
         this.foundIncreasePixelIds = new List<PixelID>();
         this.unplacedPixelIds = twoDGrid.GridPointIds();
         this.properties = props;
+        this.borderExclusionRatio = 0.2f;
     }
 
     // for each iteration step,
     // 1) ask the different peaks if they have found an increase
-    //    if yes -- make new peak, otherwise
+    //    if yes -- make new peak, also, pixel that found increase
+    //    should get transferred to rejected pixel list
+    //    if no increse found, then ... otherwise
     // 2) ask the different peaks to suggest 
     //    their next target pixel(s)
     // 3) find highest valued pixel(s)
@@ -69,10 +73,12 @@ public class TwoDGridPartitionFinder
                 TwoDPeak nthPeak = peaks[peakKey];
                 if (nthPeak.HasFoundIncrease()) {
                     // need to clean out the 'HasFoundIncrease' flag from the peaks
-                    // this will get done by the caller if we return the 'found increase' flag
+                    // this will get done for all the peaks by the caller if
+                    // we return the 'found increase' flag
                     return ReturnCode.foundIncrease; 
                 }
             }
+
 
             // step 2
             candidateRanker.Clear();
@@ -126,7 +132,7 @@ public class TwoDGridPartitionFinder
                 List<PixelSuggestion> tempCandidates = bestCandidates;
                 bestCandidates = new List<PixelSuggestion>();
                 // remove the collisions from bestCandidates
-                // add the ids to rejectedPixelIds
+                // add the ids to peakBorderPixelIds
                 // notify peaks of rejection
 
                 foreach (PixelSuggestion suggestion in tempCandidates)
@@ -143,7 +149,7 @@ public class TwoDGridPartitionFinder
 
                 foreach (PixelID pixelId in collisions)
                 {
-                    rejectedPixelIds.Add(pixelId);
+                    peakBorderPixelIds.Add(pixelId);
                     unplacedPixelIds.Remove(pixelId);
                 }
             }
@@ -175,7 +181,7 @@ public class TwoDGridPartitionFinder
     public void Clear()
     {
         peaks.Clear();
-        rejectedPixelIds.Clear();
+        peakBorderPixelIds.Clear();
         unplacedPixelIds.Clear();
         unplacedPixelIds = grid.GridPointIds();
     }
@@ -284,7 +290,47 @@ public class TwoDGridPartitionFinder
                         break;
                     }
             }
-      
+        }
+
+        // now, the peaks dictionary is complete, but there is still work to do in cleaning up the borders
+        // each peak has some pixels in its borderPixelIds list, and our algorithm has a collection 
+        // of pixelIds in its "collisions" list
+        // together, these pixels constitute the boundaries between the identified peaks.
+        // Part of the algorithm should be to establish a border zone between the peaks of a certain width
+        // because voxels near the borders could indeed be part of the tail in either region.
+        // So, lets define a parameter W, between 0 and 1 but likely around 0.25, such that any pixel 
+        // whose distance to a border/collision pixel is less than W times its distance to the peak max
+        // should be considered as part of the border region, and therefore voxels that land in the 
+        // those pixels should not get a designation from either peak.  Lets call that
+        // W parameter the borderExclusionRatio
+
+        // So, to do that calculation now, first, generate a list of all the collision/border pixel IDs
+        // loop through all the pixels identified to be part of each peak, and test for this condition.
+        // This seems like it should be an O(2) operation, because both the number of peak pixels and 
+        // the number of border pixels grow as the grid size gets smaller, but the number of border pixels 
+        // only grows as the root of number of pixels in the peak, so the complexity scaling is actually
+        // not as bad as it might seem.  Still, this will be an issue for the smallest grid sizes.
+
+        foreach (var peak in peaks.Values)
+        {
+            var borderIds = peak.BorderPixelIds();
+            peakBorderPixelIds.UnionWith(borderIds);
+        }
+
+        // now peakBorderPixelIds contains all the borderIds
+        // run the loop through all the peaks
+        //
+        // FURURE: at some point, we might consider
+        // remembering which peaks were on the border, so that 
+        // we have more information about how to assign voxels.
+        // i.e. rather than just have voxels in these pixels get a ? 
+        // designation, we do have some information about which regions they
+        // might be a part of
+        List<PixelID> excludedPixelIDs = new List<PixelID>();
+        foreach (var peak in peaks.Values)
+        {
+            List<PixelID> peakExcludedPixelIds = peak.ExcludePixelsNear(peakBorderPixelIds, borderExclusionRatio);
+            excludedPixelIDs.AddRange(peakExcludedPixelIds);
         }
     }
 

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/TwoDPeak.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using System.Collections.Generic;
 using System;
 using PcaExtensionMethods;
+using System.Linq;
 
 namespace Cameca.CustomAnalysis.Pca.VoxelLogic;
 
@@ -86,7 +88,8 @@ public class TwoDPeak
     public PeakID peakId;
     readonly PixelID peakMaxPixelId; // this is also the id for this object in container's dictionary
     readonly List<PixelID> borderPixelIds;
-    readonly List<PixelID> inPeakPixelIds;
+    readonly HashSet<PixelID> inPeakPixelIds;
+    readonly List<PixelID> excludedPixelIds;
     readonly List<PixelSuggestion> nextCandidates;
     readonly List<PixelSuggestion> topCandidates; // this list is recycled as the return vehicle for getting next suggestions
     readonly DensityPlane referenceGrid;
@@ -100,8 +103,9 @@ public class TwoDPeak
         this.partitionFinder = partitionFinder;
         this.peakMaxPixelId = peakMaxPixelId;
         this.peakId = new PeakID(peakMaxPixelId);
-        this.inPeakPixelIds = new List<PixelID>();
+        this.inPeakPixelIds = new HashSet<PixelID>();
         this.borderPixelIds = new List<PixelID>();
+        this.excludedPixelIds = new List<PixelID>();
         this.nextCandidates = new List<PixelSuggestion>();
         this.topCandidates = new List<PixelSuggestion>();
         this.referenceGrid = grid;
@@ -114,15 +118,67 @@ public class TwoDPeak
         nextCandidates.Add(firstSuggestion);
     }
 
+    // this gets called at the final step of PartitionFinder -- 
+    // the algorithm says we should have a zone around the border between peaks
+    // such that pixel closer that PMD * W to a borderPixel should not be considered
+    // part of the peak, where W is the borderExclusionRatio, and 
+    // PMD is the distance of the pixel to its peak maximum pixel.
+    public List<PixelID> ExcludePixelsNear(HashSet<PixelID> allBorderPixelIds, float borderExclusionRatio)
+    {
+
+        // pixel coords are integers of the pixel grid
+        PixelCoords peakMaxPixelCoords = peakMaxPixelId.PixelCoords();
+        float borderExclusionRatioSquared = borderExclusionRatio * borderExclusionRatio;
+        List<PixelID> excludedPixels = new List<PixelID>();
+
+        foreach (var pixelID in inPeakPixelIds)
+        {
+            // first calculate the distance of each peak pixel to the peak max  
+            // and to avoid an expensive squareroot calculation, use the
+            // distance squared in our comparisons
+            var dSquaredToPeakMax = pixelID.DSquaredTo(peakMaxPixelCoords);
+            var pixelCoords = pixelID.PixelCoords();
+            foreach (var borderPixel in allBorderPixelIds)
+            {
+                var dSquaredToBorder = borderPixel.DSquaredTo(pixelCoords);
+
+                // here, we want to test if
+                //      dToBorder < dToPeakMax * borderExclusionRatio
+                // that's the same test as 
+                //      dSquaredToBorder < dSquaredToPeakMax * borderExclusionRatioSquared
+                // assuming none of the values are negative (LOL)
+
+                if (dSquaredToBorder < dSquaredToPeakMax * borderExclusionRatioSquared)
+                {
+                    // In this case, the pixel is closer to the border than the threshold -- 
+                    // it should be part of the border zone, and not part of the peak
+                    excludedPixels.Add(pixelID);
+                    break; // exit the borderPixel foreach loop
+                }
+            }
+        }
+
+        // all the pixels in the excludedPixels HashMap should be taken out of the 
+        // inPeakPixelIds
+        inPeakPixelIds.ExceptWith(excludedPixels);
+        return excludedPixels;
+    }
+
     public List<PixelID> PixelList()
     {
-        return inPeakPixelIds;
+        return inPeakPixelIds.ToList();
+    }
+
+    public List<PixelID> BorderPixelIds()
+    {
+        return borderPixelIds;
     }
 
     public bool HasFoundIncrease()
     {
         return foundIncreaseIds.Count > 0;
     }
+
     // if suggestion accepted, remove from list and 
     // add adjacent pixels to list
     public void RemoveFromCandidates(PixelSuggestion suggestion)


### PR DESCRIPTION
In the 2D peak identification algorithm, remove pixels from peaks which are close to the border between peaks.  Introduces the concept of a "border exclusion ratio".  Future PR will expose this parameter to the user.

The effect of this is to increase the number of voxels with a ? designation for a given grid.  This makes sense because in the region near the saddle point between two peaks in a 2D grid, it isn't obvious which peak the voxels belong in, because there's overlap there.

Currently, the "border exclusion ratio" is set to 0.2.   What this means is that, when examining a 2D grid and trying to partition pixels in the projection into being part of one peak or another, there are some voxels near the interface between the peaks which are not part of either peak.

The algorithm has always identified pixels at the "valley" between the peak as being "border pixels".  This PR increases the width of the border zone by the following criterion:  Any pixel close enough to a border pixel such that its distance to the border is less that 0.2 (the hard-coded "border exclusion ratio) times its distance to its peak maximum pixel is excluded from being part of the peak.

I hope that a future PR will show the peak partitioning better, so that user can see the results or the effect of the "border exclusion ratio"