### PR TITLE
Ohellman/peak identification

### DIFF
--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -63,7 +63,7 @@
                             <Label Grid.Column="0" Target="ColorMapMaxTextBox" Content="Max" Padding="0 0 8 0" />
                             <TextBox Grid.Column="1" x:Name="ColorMapMaxTextBox">
                                 <TextBox.Text>
-                                    <Binding Path="ColorMap.TopValue"
+                                    <Binding Path="ComponentsColorMap.TopValue"
                                              UpdateSourceTrigger="PropertyChanged"
                                              Delay="500">
                                         <Binding.ValidationRules>
@@ -88,7 +88,7 @@
                             <Label Grid.Column="0" Target="ColorMapMinTextBox" Content="Min" Padding="0 0 8 0" />
                             <TextBox Grid.Column="1" x:Name="ColorMapMinTextBox">
                                 <TextBox.Text>
-                                    <Binding Path="ColorMap.BottomValue"
+                                    <Binding Path="ComponentsColorMap.BottomValue"
                                              UpdateSourceTrigger="PropertyChanged"
                                              Delay="500">
                                         <Binding.ValidationRules>

--- a/Cameca.CustomAnalysis.Pca/Utils/PcaInfoNumberFormatter.cs
+++ b/Cameca.CustomAnalysis.Pca/Utils/PcaInfoNumberFormatter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cameca.CustomAnalysis.Pca.Utils
+{
+
+    public class PcaInfoNumberFormatter
+    {
+        public PcaInfoNumberFormatter()
+        {
+        }
+
+        // the input should be a string like "17.435" or 198.00"
+        // we would like the trailing zeros in "198.00" to go away
+        private string RemoveTrailingZeros(string val)
+        {
+            val.TrimEnd('0');
+
+            val.TrimEnd('.');
+            return val;
+        }
+
+        public string StringForGridInfoTable(float val)
+        {
+            if (val == 0.0)
+            {
+                return "0";
+            }
+            if (val > 1000)
+            {
+                return val.ToString("F0");
+            }
+            if (val > 100)
+            {
+                return RemoveTrailingZeros(val.ToString("F1"));
+            }
+            if (val > 10)
+            {
+                return RemoveTrailingZeros(val.ToString("F2"));
+            }
+            if (val > 1)
+            {
+                return RemoveTrailingZeros(val.ToString("F3"));
+            }
+             return RemoveTrailingZeros(val.ToString("F4"));
+        }
+    }
+}

--- a/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
+++ b/Cameca.CustomAnalysis.Pca/VoxelLogic/PcaScoresGrid.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO;
 
 using Cameca.CustomAnalysis.Pca.Models;
+using Cameca.CustomAnalysis.Pca.Utils;
 namespace Cameca.CustomAnalysis.Pca.VoxelLogic;
 
 // PcaScoresGrid represents a three dimensional grid containing the PCA scores for a collection of voxels
@@ -1085,6 +1086,7 @@ public class PcaScoresGrid
         var gridId = new TwoDGridID(gridString);
         if (twoDPartitions.ContainsKey(gridId))
         {
+            PcaInfoNumberFormatter formatter = new PcaInfoNumberFormatter();
             List<List<PixelID>> lists = twoDPartitions[gridId];
             DensityPlane plane = twoDGrids[gridId];
             int regionCount = lists.Count;
@@ -1092,24 +1094,39 @@ public class PcaScoresGrid
             for (int r = 0; r < regionCount; ++r)
             {
                 List<PixelID> rthList = lists[r];
-                int peakCount = rthList.Count;
+                int peakPixelCount = rthList.Count;
+                float peakVoxelCount = 0.0f;
                 // calculate center of peak
-                float xSum = 0.0f;
-                float ySum = 0.0f;
+                float xPixelCoordSum = 0.0f;
+                float yPixelCoordSum = 0.0f; 
+                float xVoxelWeightSum = 0.0f;
+                float yVoxelWeightSum = 0.0f;
                 foreach (PixelID pixelId in rthList)
                 {
                     (float nthX, float nthY) = plane.XYCoordsFor(pixelId);
-                    xSum += nthX;
-                    ySum += nthY;
+                    float nthPixelValue = plane.ValueAtPixel(pixelId);
+                    peakVoxelCount += nthPixelValue;
+                    xPixelCoordSum += nthX;
+                    yPixelCoordSum += nthY;
+                    xVoxelWeightSum += nthX * nthPixelValue;
+                    yVoxelWeightSum += nthY * nthPixelValue;
                 }
-                float xCenter = xSum / peakCount;
-                float yCenter = ySum / peakCount;
-                float area = peakCount * plane.binsize * plane.binsize;
+                float xPixelCoordsCenter = xPixelCoordSum / peakPixelCount;
+                float yPixelCoordsCenter = yPixelCoordSum / peakPixelCount;
+                float xVoxelWeightCenter = xVoxelWeightSum / peakVoxelCount;
+                float yVoxelWeightCenter = yVoxelWeightSum / peakVoxelCount;
+                float area = peakPixelCount * plane.binsize * plane.binsize;
+
+                // note:  x and y are swapped in the UI display,
+                // so we label yCenter as "x center" and xCenter as "y center"
                 info += "\n  region " + r 
-                      + "\n    pixels: " + peakCount.ToString()
-                      + "\n    area: " + area.ToString()
-                      + "\n    x center: " + xCenter.ToString()
-                      + "\n    y center: " + yCenter.ToString();
+                      + "\n    pixels: " + peakPixelCount.ToString()
+                      + "\n    area: " + formatter.StringForGridInfoTable(area)
+                      + "\n    voxels: " + formatter.StringForGridInfoTable(peakVoxelCount)
+                      + "\n    centroid x: " + formatter.StringForGridInfoTable(yPixelCoordsCenter) 
+                      + " , y: " + formatter.StringForGridInfoTable(xPixelCoordsCenter) 
+                      + "\n    center of mass x: " + formatter.StringForGridInfoTable(yPixelCoordsCenter) 
+                      + " , y: " + formatter.StringForGridInfoTable(xPixelCoordsCenter);
             }
         }
 


### PR DESCRIPTION
This PR fixes an issue where the Binding to the ColorMap in the Scores Panel in pcaView.xaml was busted in a previous commit.

Additionally, this adds a bit more detail to the info description for the two 2D grid display, as well as fixes some confusion caused by the sway of the x and y grid components.