### PR TITLE
Olof/loadings cycle buttons

### DIFF
--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -131,7 +131,6 @@
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
@@ -151,7 +150,53 @@
                                 ButtonContent="Update"
                                 OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid>
-                        <lvc:CartesianChart Series="{Binding LoadingsSeries}"
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <StackPanel
+                             Grid.Column="0" 
+                             Grid.Row="0"
+                             Grid.RowSpan="2"
+                             Orientation="Vertical" 
+                             HorizontalAlignment="Center"
+                             Background="#efefef">
+                            <Button x:Name="PreviousComponentButton" 
+                                Content="Go to Previous Component" 
+                                Height="32" 
+                                Width="160"
+                                Click="PreviousComponentButton_Click" 
+                                Margin="10,10,10,0">
+                            </Button>
+                            <Button x:Name="AdvanceComponentButton" 
+                                Content="Advance To Next Component" 
+                                Height="32" 
+                                Width="160"
+                                Click="AdvanceComponentButton_Click" 
+                                Margin="10,10,10,10">
+                            </Button>
+                        </StackPanel>
+                        <Label x:Name="GridLabel" 
+                            Grid.Column="1" 
+                            Grid.Row="0" 
+                            Content="Loadings" 
+                            Height="32" 
+                            Width="140" 
+                            FontSize="16" 
+                            FontFamily="Calibri"  
+                            FontWeight="Bold"   
+                            Background="White"   
+                            Foreground="Black">
+                        </Label>
+
+                        <lvc:CartesianChart Grid.Column="1"
+                                            Grid.Row="1"
+                                            Grid.RowSpan="2"
+                                            Series="{Binding LoadingsSeries}"
                                             DisableAnimations="True"
                                             LegendLocation="None"
                                             Visibility="{Binding LoadingHistogramRenderData, Converter={local:CollectionVisibilityConverter Invert=True}}">
@@ -174,7 +219,10 @@
                             </lvc:CartesianChart.AxisY>
                         </lvc:CartesianChart>
 
-                        <controls:Chart2D DataSource="{Binding LoadingHistogramRenderData}"
+                        <controls:Chart2D Grid.Column="1"
+                                          Grid.Row="1"
+                                          Grid.RowSpan="2"
+                                          DataSource="{Binding LoadingHistogramRenderData}"
                                           Projection="XZ"
                                           AxisYLabel="Loadings"
                                           AxisXLabel="Bin Index"

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -151,12 +151,12 @@
                                 OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="200" />
+                            <ColumnDefinition Width="188" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="32" />
-                            <RowDefinition Height="32" />
+                            <RowDefinition Height="36" />
+                            <RowDefinition Height="36" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
                         <Button x:Name="PreviousComponentButton" 
@@ -164,7 +164,7 @@
                                 Grid.Column="0" 
                                 Grid.Row="0"
                                 Height="32" 
-                                Width="160"
+                                Width="180"
                                 Click="PreviousComponentButton_Click" 
                                 Margin="2,2,2,2">
                         </Button>
@@ -173,7 +173,7 @@
                                 Grid.Column="0" 
                                 Grid.Row="1"
                                 Height="32" 
-                                Width="160"
+                                Width="180"
                                 Click="AdvanceComponentButton_Click" 
                                 Margin="2,2,2,2">
                         </Button>

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml
@@ -151,48 +151,44 @@
                                 OverlayVisibility="{Binding UpdateSelectedComponentCanExecute, Converter={StaticResource BooleanToVisibilityConverter}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="200" />
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="32" />
+                            <RowDefinition Height="32" />
                             <RowDefinition Height="*" />
-                            <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <StackPanel
-                             Grid.Column="0" 
-                             Grid.Row="0"
-                             Grid.RowSpan="2"
-                             Orientation="Vertical" 
-                             HorizontalAlignment="Center"
-                             Background="#efefef">
-                            <Button x:Name="PreviousComponentButton" 
+                        <Button x:Name="PreviousComponentButton" 
                                 Content="Go to Previous Component" 
+                                Grid.Column="0" 
+                                Grid.Row="0"
                                 Height="32" 
                                 Width="160"
                                 Click="PreviousComponentButton_Click" 
-                                Margin="10,10,10,0">
-                            </Button>
-                            <Button x:Name="AdvanceComponentButton" 
+                                Margin="2,2,2,2">
+                        </Button>
+                        <Button x:Name="AdvanceComponentButton" 
                                 Content="Advance To Next Component" 
+                                Grid.Column="0" 
+                                Grid.Row="1"
                                 Height="32" 
                                 Width="160"
                                 Click="AdvanceComponentButton_Click" 
-                                Margin="10,10,10,10">
-                            </Button>
-                        </StackPanel>
+                                Margin="2,2,2,2">
+                        </Button>
                         <Label x:Name="GridLabel" 
                             Grid.Column="1" 
                             Grid.Row="0" 
-                            Content="Loadings" 
+                            Content="{Binding LoadingsChartTitle}"
                             Height="32" 
-                            Width="140" 
+                            Width="280" 
                             FontSize="16" 
                             FontFamily="Calibri"  
                             FontWeight="Bold"   
                             Background="White"   
                             Foreground="Black">
                         </Label>
-
                         <lvc:CartesianChart Grid.Column="1"
                                             Grid.Row="1"
                                             Grid.RowSpan="2"

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml.cs
@@ -1,12 +1,30 @@
-﻿namespace Cameca.CustomAnalysis.Pca;
+﻿using System.Windows;
+
+namespace Cameca.CustomAnalysis.Pca;
 
 /// <summary>
 /// Interaction logic for PcaView.xaml
 /// </summary>
 internal partial class PcaView
 {
+
     public PcaView()
     {
         InitializeComponent();
+    }
+
+    private void AdvanceComponentButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is PrincipalComponentAnalysis pca)
+        {
+            pca.IncrementComponentIndex(1);
+        }
+    }
+    private void PreviousComponentButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is PrincipalComponentAnalysis pca)
+        {
+            pca.IncrementComponentIndex(-1);
+        }
     }
 }

--- a/Cameca.CustomAnalysis.Pca/PcaView.xaml.cs
+++ b/Cameca.CustomAnalysis.Pca/PcaView.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Threading;
+using System.Windows;
 
 namespace Cameca.CustomAnalysis.Pca;
 
@@ -7,24 +8,38 @@ namespace Cameca.CustomAnalysis.Pca;
 /// </summary>
 internal partial class PcaView
 {
-
-    public PcaView()
+    CancellationTokenSource cancellationTokenSource;
+    CancellationToken? incrementIndexCancellationToken = null;
+     public PcaView()
     {
         InitializeComponent();
+        cancellationTokenSource = new CancellationTokenSource();
     }
 
-    private void AdvanceComponentButton_Click(object sender, RoutedEventArgs e)
+    private async void AdvanceComponentButton_Click(object sender, RoutedEventArgs e)
     {
         if (DataContext is PrincipalComponentAnalysis pca)
         {
-            pca.IncrementComponentIndex(1);
+            if (incrementIndexCancellationToken == null)
+            {
+                var cancellationToken = cancellationTokenSource.Token;
+                incrementIndexCancellationToken = cancellationToken;
+                await pca.IncrementComponentIndex(1, cancellationToken);
+                incrementIndexCancellationToken = null;
+            }
         }
     }
-    private void PreviousComponentButton_Click(object sender, RoutedEventArgs e)
+    private async void PreviousComponentButton_Click(object sender, RoutedEventArgs e)
     {
         if (DataContext is PrincipalComponentAnalysis pca)
         {
-            pca.IncrementComponentIndex(-1);
+            if (incrementIndexCancellationToken == null)
+            {
+                var cancellationToken = cancellationTokenSource.Token;
+                incrementIndexCancellationToken = cancellationToken;
+                await pca.IncrementComponentIndex(-1, cancellationToken);
+                incrementIndexCancellationToken = null;
+            }
         }
     }
 }

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -127,10 +127,15 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
                 ? !LoadingHistogramRenderData.Any()
                 : !LoadingsSeries.Any() || !LoadingsLabels.Any() || !ScoresHistogramRenderData.Any();
         }
-    }
+    } 
 
     public Func<double, string> AxisYLabelFormatter { get; } = (double value) => value.ToString("F3");
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
+    [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
+    private string loadingsChartTitle = "Loadings";
+    
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(UpdateSelectedComponentCanExecute))]
     [NotifyCanExecuteChangedFor(nameof(UpdateSelectedComponentCommand))]
@@ -450,13 +455,34 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         UpdateOptionsBounds();
 
         // Ensure that the selected component falls in the valid range of number of components
-        if (Properties.PcaPhaseIndex < 0)
+        // operate on a local variable and update only on a change so that we dont
+        // trigger the ObservedPropertyChanges callbacks
+        var inRangeIndex = Properties.ComponentIndex;
+        if (inRangeIndex >= Properties.NumberOfComponents)
         {
-            Properties.ComponentIndex = 0;
+            inRangeIndex = Properties.NumberOfComponents - 1;
         }
-        else if (Properties.ComponentIndex > Properties.NumberOfComponents)
+        if (inRangeIndex < 0)
         {
-            Properties.ComponentIndex = Properties.NumberOfComponents;
+            inRangeIndex = 0;
+        }
+        if (inRangeIndex != Properties.ComponentIndex)
+        {
+            Properties.ComponentIndex = inRangeIndex;
+        }
+
+        inRangeIndex = Properties.PcaPhaseIndex;
+        if (inRangeIndex >= Properties.NumberOfComponents)
+        {
+            inRangeIndex = Properties.NumberOfComponents - 1;
+        }
+        if (inRangeIndex < 0)
+        {
+            inRangeIndex = 0;
+        }
+        if (inRangeIndex != Properties.PcaPhaseIndex)
+        {
+            Properties.PcaPhaseIndex = inRangeIndex;
         }
 
         await UpdateHistograms(cancellationToken);
@@ -544,7 +570,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         int numComponents = Properties.NumberOfComponents;
         int selectedIndex = Properties.ComponentIndex;
 
-        if (PcaComponentsResults is null)
+        if ((PcaComponentsResults is null) || (PcaComponentsResults.Components.Count() == 0))
         {
             await UpdateComponents(cancellationToken);
         }
@@ -1022,8 +1048,15 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private void UpdateOptionsBounds()
     {
         var selectedResult = PcaComponentsResults?.Components.ElementAtOrDefault(Properties.ComponentIndex);
-        Properties.Min = selectedResult?.Scores.Min();
-        Properties.Max = selectedResult?.Scores.Max();
+        if (selectedResult != null)
+        {
+            var nonnullSelectedResult = (ComponentData)selectedResult;
+            if (nonnullSelectedResult.Scores != null)
+            {
+                Properties.Min = nonnullSelectedResult.Scores.Min();
+                Properties.Max = nonnullSelectedResult.Scores.Max();
+            }
+        }
     }
 
     // Applies filter to the custom analysis: returns the ions in voxels for which the score of the selected component exceeds the specified threshold value
@@ -1178,6 +1211,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         LoadingHistogramRenderData = Array.Empty<IRenderData>();
         LoadingsSeries = new SeriesCollection();
         LoadingsLabels = Array.Empty<string>();
+        LoadingsChartTitle = "Loadings for Component " + Properties.ComponentIndex.ToString();
     }
 
     private void InvalidateAll()

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -1255,7 +1255,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         PcaPhaseIDResults = null;
     }
 
-    public void IncrementComponentIndex(int incr)
+    public async Task IncrementComponentIndex(int incr, CancellationToken token)
     {
         var currentIndex = Properties.ComponentIndex;
         var newIndex = currentIndex + incr;
@@ -1267,7 +1267,8 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         {
             newIndex = Properties.NumberOfComponents - 1;
         }
-        Properties.NumberOfComponents = newIndex;
+        Properties.ComponentIndex = newIndex;
+        UpdateSelectedComponent(token);
     }
     // Should actually be implemented in the base class CoreNodeBase along with existing DataStateIsValid.
     // Remove after a Cameca.CustomAnalysis.Utilities updates adds this functionality

--- a/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/PrincipalComponentAnalysis.cs
@@ -529,7 +529,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         }
     }
 
-    // Uses the component data (or computes for all componets if necessary) to generate plots for the selected component by index
+    // Uses the component data (or computes for all components if necessary) to generate plots for the selected component by index
     [RelayCommand(CanExecute = nameof(UpdateSelectedComponentCanExecute))]
     public async Task UpdateSelectedComponent(CancellationToken cancellationToken)
     {
@@ -1221,6 +1221,20 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         PcaPhaseIDResults = null;
     }
 
+    public void IncrementComponentIndex(int incr)
+    {
+        var currentIndex = Properties.ComponentIndex;
+        var newIndex = currentIndex + incr;
+        if (newIndex >= Properties.NumberOfComponents)
+        {
+            newIndex = 0;
+        }
+        if (newIndex < 0)
+        {
+            newIndex = Properties.NumberOfComponents - 1;
+        }
+        Properties.NumberOfComponents = newIndex;
+    }
     // Should actually be implemented in the base class CoreNodeBase along with existing DataStateIsValid.
     // Remove after a Cameca.CustomAnalysis.Utilities updates adds this functionality
     protected bool DataStateIsError


### PR DESCRIPTION
This PR adds cycle buttons (advance/previous) to the Loadings tab

The implementation of these buttons is completely different from that of the analogous buttons in the Grids and scores tabs.  Among the differences:

- The increment decrement is hooked up to the PCA property "ComponentIndex", so the value changes in the Properties pane

- There is no separate .xaml for the Loadings pane, so the button handling in done in the code-behind for the PcaView.xaml file

- Because the operation needs to invoke the async "UpdateSelectedComponent()" function, the click handler is declared as asynchronous, and there's a need to create a cancellationToken before invoking it.

- I don't know of a way to have an element in the left side of the pane to have a slightly tinted background like in the other panes, so it's just white.  Maybe there is a way to tinker with Grid properties?
- 
Additionally, fixed a lingering bug relat ed to bounds checking of the ComponentIndex, which stayed under the radar until I started changing the ComponentIndex.

