### PR TITLE
Make nullable return from ionData.GetVoxelFeatureMatrixSectionData  explicit, handle null returns

### DIFF
--- a/Cameca.CustomAnalysis.Pca/Features/BaseClustering/BaseClusteringAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/BaseClustering/BaseClusteringAnalysis.cs
@@ -80,7 +80,11 @@ internal abstract partial class BaseClusteringAnalysis<TProperties> : BasicCusto
         {
             return;
         }
-        var data = ionData.GetVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        var data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        if (data is null || data.VoxelFeatureMatrix.DataLength == 0)
+        {
+            return;
+        }
 
         var existingResults = IonAssignmentSerializer.ReadFromIonDataSection(ionData, Resources.DataSectionName);
         var sanitizedResults = existingResults ?? CalculateClustering(ionData, data);

--- a/Cameca.CustomAnalysis.Pca/Features/BaseClustering/BaseClusteringAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/BaseClustering/BaseClusteringAnalysis.cs
@@ -80,7 +80,7 @@ internal abstract partial class BaseClusteringAnalysis<TProperties> : BasicCusto
         {
             return;
         }
-        var data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        var data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName, () => DataStateIsError, (errVal) => DataStateIsError = errVal);
         if (data is null || data.VoxelFeatureMatrix.DataLength == 0)
         {
             return;

--- a/Cameca.CustomAnalysis.Pca/Features/PackedDataSection/PackedDataSerializer.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/PackedDataSection/PackedDataSerializer.cs
@@ -3,6 +3,7 @@ using Cameca.CustomAnalysis.Utilities;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 
@@ -24,6 +25,10 @@ internal static class PackedDataSerializer
 
     public static PackedDataDefinition<TExtraData>? Read<TExtraData>(IIonData ionData, string sectionName) where TExtraData : class
     {
+        if (!IonDataHasSection(ionData, sectionName))
+        {
+            return null;
+        }
         if (!TryGetPinnedHandle(ionData, sectionName, out var handle))
         {
             return null;
@@ -46,6 +51,12 @@ internal static class PackedDataSerializer
 
         return new PackedDataDefinition<TExtraData>(extraData, packedData);
     }
+
+    private static bool IonDataHasSection(IIonData ionData, string sectionName)
+    {
+        IReadOnlyDictionary<string, ISectionInfo> sections = ionData.Sections;
+        return sections.Keys.Contains(sectionName);
+	}
 
     private static bool TryGetPinnedHandle(IIonData ionData, string sectionName, out MemoryHandle handle)
     {

--- a/Cameca.CustomAnalysis.Pca/Features/Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/Pca/PrincipalComponentAnalysis.cs
@@ -93,7 +93,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     private GridMethod? SelectedGridMethod => Resources.GetValidIonData() is { } ionData
-        ? GetVoxelFeatureData(ionData).ExtraData.GridMethod
+        ? GetNullableVoxelFeatureData(ionData).ExtraData.GridMethod
         : null;
 
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
@@ -178,7 +178,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         if (await Resources.GetIonData(null, cancellationToken) is not { } ionData
             || ((Analysis ??= await GetAnalysis(cancellationToken)) is not { } pca)
             || pca.Matrix.DataLength == 0
-            || GetVoxelFeatureData(ionData) is not { } data)
+            || GetNullableVoxelFeatureData(ionData) is not { } data)
         {
             DataStateIsError = true;
             return;
@@ -230,6 +230,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     private async Task<EigenvalueResults?> GetEigenvalueResults(CancellationToken cancellationToken)
     {
         var pca = await GetAnalysis();
+        if (pca == null)
+        {
+            return null;
+        }
         var scores = pca.GetEigenvalues();
         return new EigenvalueResults(scores);
     }
@@ -247,11 +251,11 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         return Analysis;
     }
 
-    private PcaLibPrincipalComponentAnalysis CreateAnalysis(IIonData ionData)
+    private PcaLibPrincipalComponentAnalysis? CreateAnalysis(IIonData ionData)
     {
-        if (GetVoxelFeatureData(ionData) is not { } data)
+        if (GetNullableVoxelFeatureData(ionData) is not { } data)
         {
-            throw new InvalidOperationException("Parent must define a VoxelFeatureMatrix");
+            return null;
         }
 
         var gridParams = data.ExtraData.GridParameters;
@@ -260,8 +264,10 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         return new PcaLibPrincipalComponentAnalysis(gridParams, matrix);
     }
 
-    private VoxelFeatureMatrixSectionData GetVoxelFeatureData(IIonData ionData)
-        => ionData.GetVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+    // Some callers to GetVoxelFeatureData expected to handle returning null here rather than having an exception thrown
+    // These callers can use this method GetNullableVoxelFeatureData() to avoid the exception
+    private VoxelFeatureMatrixSectionData? GetNullableVoxelFeatureData(IIonData ionData)
+        => ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
 
     // Updates the noise eigenvalues tab plot when the computed eigenvalue data changes
     partial void OnEigenvalueResultsChanged(EigenvalueResults? value)

--- a/Cameca.CustomAnalysis.Pca/Features/Pca/PrincipalComponentAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/Pca/PrincipalComponentAnalysis.cs
@@ -93,7 +93,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     }
 
     private GridMethod? SelectedGridMethod => Resources.GetValidIonData() is { } ionData
-        ? GetNullableVoxelFeatureData(ionData).ExtraData.GridMethod
+        ? GetNullableVoxelFeatureData(ionData)?.ExtraData.GridMethod
         : null;
 
     public bool UpdateRankEstimationCanExecute => NoiseEigenvalueResults is null;
@@ -238,7 +238,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
         return new EigenvalueResults(scores);
     }
 
-    private async Task<PcaLibPrincipalComponentAnalysis> GetAnalysis(CancellationToken cancellationToken = default)
+    private async Task<PcaLibPrincipalComponentAnalysis?> GetAnalysis(CancellationToken cancellationToken = default)
     {
         if (Analysis is null)
         {
@@ -267,7 +267,7 @@ internal partial class PrincipalComponentAnalysis : BasicCustomAnalysisBase<PcaP
     // Some callers to GetVoxelFeatureData expected to handle returning null here rather than having an exception thrown
     // These callers can use this method GetNullableVoxelFeatureData() to avoid the exception
     private VoxelFeatureMatrixSectionData? GetNullableVoxelFeatureData(IIonData ionData)
-        => ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        => ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName, () => DataStateIsError, (errVal) => DataStateIsError = errVal);
 
     // Updates the noise eigenvalues tab plot when the computed eigenvalue data changes
     partial void OnEigenvalueResultsChanged(EigenvalueResults? value)

--- a/Cameca.CustomAnalysis.Pca/Features/PcaSuiteUtils.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/PcaSuiteUtils.cs
@@ -17,13 +17,10 @@ internal static class PcaSuiteUtils
         return (new UnmanagedMemoryManager<float>(nativePtr, dataLength)).Memory;
     }
 
-    public static VoxelFeatureMatrixSectionData GetVoxelFeatureMatrixSectionData(this IIonData ionData, string sectionName)
+    // Callers to GetNullableVoxelFeatureMatrixSectionData must handle the case where null is returned.
+    public static VoxelFeatureMatrixSectionData? GetNullableVoxelFeatureMatrixSectionData(this IIonData ionData, string sectionName)
     {
         // This isn't the top level -- .Parent! is safe
-        if (VoxelFeatureMatrixSerializer.ReadFromIonDataSection(ionData, sectionName) is not { } data)
-        {
-            throw new InvalidOperationException("Section does not define a VoxelFeatureMatrix");
-        }
-        return data;
+        return VoxelFeatureMatrixSerializer.ReadFromIonDataSection(ionData, sectionName);
     }
 }

--- a/Cameca.CustomAnalysis.Pca/Features/PcaSuiteUtils.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/PcaSuiteUtils.cs
@@ -1,6 +1,7 @@
 ﻿using Cameca.CustomAnalysis.Interface;
 using Cameca.CustomAnalysis.PcaLib.Interface;
 using System;
+using System.Windows;
 
 namespace Cameca.CustomAnalysis.Pca;
 
@@ -18,9 +19,18 @@ internal static class PcaSuiteUtils
     }
 
     // Callers to GetNullableVoxelFeatureMatrixSectionData must handle the case where null is returned.
-    public static VoxelFeatureMatrixSectionData? GetNullableVoxelFeatureMatrixSectionData(this IIonData ionData, string sectionName)
+    public static VoxelFeatureMatrixSectionData? GetNullableVoxelFeatureMatrixSectionData(this IIonData ionData, string sectionName, Func<bool> getErrorState, Action<bool> setErrorState)
     {
-        // This isn't the top level -- .Parent! is safe
-        return VoxelFeatureMatrixSerializer.ReadFromIonDataSection(ionData, sectionName);
+        var sectionData = VoxelFeatureMatrixSerializer.ReadFromIonDataSection(ionData, sectionName);
+        // If could not resolve the VoxelFeatureMatrixSectionData, then warn the user, set error state to true, and return null.
+        // Retrieve existing error state to avoid showing the message box multiple times.
+        if (sectionData is null && !getErrorState())
+        {
+            MessageBox.Show("There are no features in the grid on which to perform the analysis.", "PCA Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            setErrorState(true);
+            return null;
+        }
+        setErrorState(sectionData is null);
+        return sectionData;
     }
 }

--- a/Cameca.CustomAnalysis.Pca/Features/SelectComponentIsovalue/SelectComponentIsovalueAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/SelectComponentIsovalue/SelectComponentIsovalueAnalysis.cs
@@ -39,7 +39,12 @@ internal partial class SelectComponentIsovalueAnalysis : StandardAnalysisFilterN
         IProgress<double>? progress,
         [EnumeratorCancellation] CancellationToken token)
     {
-        var data = ownerIonData.GetVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        var nullableData = ownerIonData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        if (nullableData is not { } data)
+        {
+            DataStateIsError = true;
+            yield break;
+        }
         DataStateIsError = false;
 
         var gridParams = data.ExtraData.GridParameters;

--- a/Cameca.CustomAnalysis.Pca/Features/SelectComponentIsovalue/SelectComponentIsovalueAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/SelectComponentIsovalue/SelectComponentIsovalueAnalysis.cs
@@ -39,7 +39,7 @@ internal partial class SelectComponentIsovalueAnalysis : StandardAnalysisFilterN
         IProgress<double>? progress,
         [EnumeratorCancellation] CancellationToken token)
     {
-        var nullableData = ownerIonData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        var nullableData = ownerIonData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName, () => DataStateIsError, (errVal) => DataStateIsError = errVal);
         if (nullableData is not { } data)
         {
             DataStateIsError = true;

--- a/Cameca.CustomAnalysis.Pca/Features/SpatialPartitioning/SpatialPartitioningAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/SpatialPartitioning/SpatialPartitioningAnalysis.cs
@@ -241,7 +241,7 @@ internal partial class SpatialPartitioningAnalysis : BasicCustomAnalysisBase<Spa
         {
             return false;
         }
-        data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName, () => DataStateIsError, (errVal) => DataStateIsError = errVal);
         if (data is null || data.VoxelFeatureMatrix.DataLength == 0)
         {
             return false;

--- a/Cameca.CustomAnalysis.Pca/Features/SpatialPartitioning/SpatialPartitioningAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/SpatialPartitioning/SpatialPartitioningAnalysis.cs
@@ -241,7 +241,7 @@ internal partial class SpatialPartitioningAnalysis : BasicCustomAnalysisBase<Spa
         {
             return false;
         }
-        data = ionData.GetVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
+        data = ionData.GetNullableVoxelFeatureMatrixSectionData(Resources.Parent!.DataSectionName);
         if (data is null || data.VoxelFeatureMatrix.DataLength == 0)
         {
             return false;

--- a/Cameca.CustomAnalysis.Pca/Features/Voxelization/VoxelizationAnalysis.cs
+++ b/Cameca.CustomAnalysis.Pca/Features/Voxelization/VoxelizationAnalysis.cs
@@ -42,11 +42,15 @@ internal partial class VoxelizationAnalysis : StandardAnalysisFilterNodeBase<Vox
         await Task.Run(() =>
         {
             var (gridParams, voxelFeatureMatrix) = CreateVoxelFeatureMatrix(ionData, progress);
+            // in the case there are no features identified, avoid writing an empty section to the ion data,
+            // this could happen if the user is making an ionTypes feature matrix before applying range data.
+            if (voxelFeatureMatrix.DataLength > 0)
+            {
+                var extraData = new VoxelFeatureMatrixExtraData(gridParams, Properties.GridMethod);
+                var data = new VoxelFeatureMatrixSectionData(extraData, voxelFeatureMatrix);
 
-            var extraData = new VoxelFeatureMatrixExtraData(gridParams, Properties.GridMethod);
-            var data = new VoxelFeatureMatrixSectionData(extraData, voxelFeatureMatrix);
-
-            VoxelFeatureMatrixSerializer.WriteToIonDataSection(ionData, Resources.DataSectionName, data);
+                VoxelFeatureMatrixSerializer.WriteToIonDataSection(ionData, Resources.DataSectionName, data);
+            }
         }, cancellationToken);
     }
 


### PR DESCRIPTION
Previously, ionData.GetVoxelFeatureMatrixSectionData could return null values, and some callers woiuld handle it, some wouldn't.  In all cases, a null return was accompanied by an exception.

This PR removes the exception throwing, and handles cases where a null gets returned as gracefully as possible.

The easy scenario to repro is the case where a 3d gris is created for IonTypes, but no ion Types are defined because no ranges are loaded.  Probably other scenarios as well.

The UI experience in this case is that clicking the "Update" button on the PCA pane appears to do nothing.