### PR TITLE
Add to Exception error message

### DIFF
--- a/Cameca.CustomAnalysis.PcaLib.Interface/PrincipalComponentAnalysis.h
+++ b/Cameca.CustomAnalysis.PcaLib.Interface/PrincipalComponentAnalysis.h
@@ -29,7 +29,7 @@ namespace Cameca::CustomAnalysis::PcaLib::Interface {
 		{
 			auto result = GetInstance()->GetEigenvalues();
 			if (result.info > 0) {
-				throw gcnew System::Exception("The iterative algorithm for computing eigenvalues or eigenvectors fails to converge with the set parameters in the permitted number of iterations. Different inputs, specifically reducing the number of voxels or features, may help correct this issue.");
+				throw gcnew System::Exception("The iterative algorithm for computing eigenvalues or eigenvectors fails to converge with the set parameters in the permitted number of iterations. Different inputs, specifically reducing the number of voxels or features, may help. If this issue is encountered with reasonable numbers of voxels and features, please report the issue with repro steps.");
 			}
 
 			return VectorMarshaller::ToArray(result.value);


### PR DESCRIPTION
Add to the exception error message for unterminated GetEigenvalues() loop so that if this is a real issue we might get repro steps.

The exception traces to line 226 of PrincipalConentAnalysis.cpp -- the call to LAPACKE_ssygvx() is followed by the line:

    //if (info != ZERO)  The algorithm didn't complete properly, need error checking code

And there is no error checking code except for an exception throw at a later point when the result of the function is retrieved.  I am hesitant to make any more invasive changes until we have repro steps to evaluate the effect of said changes.